### PR TITLE
Add support for specific Amazon offer IDs in cart

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,21 @@ shop cart remove B0D1XD1ZV3           # Remove item
 shop cart clear                       # Empty the cart
 ```
 
+To add a specific Amazon offer, pass its ID alongside the product ASIN:
+
+```bash
+shop cart add B0D1XD1ZV3 --offer-id '<offer-id>' --qty 2 --store amazon
+```
+
+The offer ID is passed unchanged to Amazon, without looking up the buy-box offer.
+Omit `--offer-id` to use the current buy-box offer. `shop offers <asin>` returns
+the buy-box offer ID in `.offers[].id`; Amazon's offers command does not list
+other sellers, but you can supply an offer ID obtained separately for the same ASIN.
+
 All cart commands return the full cart snapshot with items and subtotal.
+
+Go callers pass `nil` to `Cart.Add(ctx, productID, quantity, nil)` for the default
+offer, or `&shop.CartAddOpts{OfferID: offerID}` as the final argument to select one.
 
 ### Checkout & Order
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -122,6 +122,16 @@ shop cart remove B0D1XD1ZV3           # remove item
 shop cart clear                       # empty cart
 ```
 
+For a specific Amazon offer, keep the ASIN as the product ID and pass the offer ID:
+
+```bash
+shop cart add B0D1XD1ZV3 --offer-id '<offer-id>' --qty 2 --store amazon
+```
+
+Pass the offer ID unchanged. Omitting `--offer-id` selects the current buy-box offer.
+`shop offers <asin>` exposes the buy-box offer ID in `.offers[].id`, not a full
+seller listing. An offer ID obtained separately can also be supplied for the same ASIN.
+
 All cart commands return full cart snapshot: `.items[]` (product + quantity) and `.subtotal`.
 
 ### Checkout (preview only)

--- a/internal/cli/cart.go
+++ b/internal/cli/cart.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	"github.com/saucesteals/shop"
@@ -23,7 +25,10 @@ func (c *CLI) newCartCmd() *cobra.Command {
 }
 
 func (c *CLI) newCartAddCmd() *cobra.Command {
-	var qty int
+	var (
+		qty     int
+		offerID string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "add <product-id>",
@@ -34,13 +39,21 @@ func (c *CLI) newCartAddCmd() *cobra.Command {
 				return shop.Errorf(shop.ErrInvalidInput, "quantity must be >= 1, got %d", qty)
 			}
 
+			if cmd.Flags().Changed("offer-id") && strings.TrimSpace(offerID) == "" {
+				return shop.Errorf(shop.ErrInvalidInput, "offer ID must not be empty")
+			}
+
 			ctx, cancel, s, err := c.resolveStore(cmd)
 			if err != nil {
 				return err
 			}
 			defer cancel()
 
-			result, err := s.Cart().Add(ctx, args[0], qty)
+			opts := &shop.CartAddOpts{
+				OfferID: offerID,
+			}
+
+			result, err := s.Cart().Add(ctx, args[0], qty, opts)
 			if err != nil {
 				return err
 			}
@@ -49,7 +62,9 @@ func (c *CLI) newCartAddCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().IntVar(&qty, "qty", 1, "quantity to add")
+	f := cmd.Flags()
+	f.IntVar(&qty, "qty", 1, "quantity to add")
+	f.StringVar(&offerID, "offer-id", "", "specific offer ID for the product (defaults to the buy-box offer on Amazon)")
 
 	return cmd
 }

--- a/internal/provider/amazon/cart.go
+++ b/internal/provider/amazon/cart.go
@@ -11,11 +11,11 @@ type cartImpl struct {
 	store *Store
 }
 
-// Add adds an item to the Amazon cart.
+// Add adds an item to the Amazon cart using the specified offer or the buy-box offer.
 //
 // TVSS endpoint: PUT /marketplaces/{marketplace}/cart/items
 // Content-Type: application/vnd.com.amazon.tvss.api+json; type="cart.add.request/v1"
-func (c *cartImpl) Add(ctx context.Context, id string, quantity int) (*shop.CartContents, error) {
+func (c *cartImpl) Add(ctx context.Context, id string, quantity int, opts *shop.CartAddOpts) (*shop.CartContents, error) {
 	if err := validateASIN(id); err != nil {
 		return nil, err
 	}
@@ -29,26 +29,33 @@ func (c *cartImpl) Add(ctx context.Context, id string, quantity int) (*shop.Cart
 		quantity = 1
 	}
 
-	// Fetch the offerId from the product detail. TVSS requires it.
-	prodURL := api.tvssPath([]string{"products", id}, nil)
-
-	var tp tvssProduct
-	if err := api.doGet(ctx, prodURL, &tp); err != nil {
-		return nil, shop.Errorf(shop.ErrNotFound, "product %s: %v", id, err)
+	var offerID string
+	if opts != nil {
+		offerID = opts.OfferID
 	}
 
-	if tp.OfferID == "" {
-		// Product exists in the catalog but has no current offer. This
-		// commonly happens when the product is out of stock in TVSS or
-		// the device type doesn't expose pricing.
-		return nil, shop.Errorf(shop.ErrOutOfStock, "product %s has no available offer", id)
+	if offerID == "" {
+		// TVSS requires an offer ID. Resolve the buy-box offer only when
+		// the caller has not selected a specific offer.
+		prodURL := api.tvssPath([]string{"products", id}, nil)
+
+		var tp tvssProduct
+		if err := api.doGet(ctx, prodURL, &tp); err != nil {
+			return nil, shop.Errorf(shop.ErrNotFound, "product %s: %v", id, err)
+		}
+
+		if tp.OfferID == "" {
+			return nil, shop.Errorf(shop.ErrOutOfStock, "product %s has no available offer", id)
+		}
+
+		offerID = tp.OfferID
 	}
 
 	req := tvssAddToCartRequest{
 		Items: []tvssAddToCartItem{
 			{
 				ASIN:     id,
-				OfferID:  tp.OfferID,
+				OfferID:  offerID,
 				Quantity: quantity,
 			},
 		},

--- a/order.go
+++ b/order.go
@@ -1,5 +1,12 @@
 package shop
 
+// CartAddOpts controls which offer is added to the cart.
+type CartAddOpts struct {
+	// OfferID is an opaque offer ID for the product. Empty selects the
+	// default offer. Providers must not substitute a different offer when set.
+	OfferID string `json:"offerId,omitempty"`
+}
+
 // CartContents is a snapshot of the current cart state.
 type CartContents struct {
 	Items    []CartEntry `json:"items"`

--- a/shop.go
+++ b/shop.go
@@ -89,7 +89,8 @@ type Store interface {
 // provider implementation — the CLI only reads it via View().
 type Cart interface {
 	// Add adds a product to the cart. quantity must be >= 1.
-	Add(ctx context.Context, id string, quantity int) (*CartContents, error)
+	// Nil opts selects the default offer for the product.
+	Add(ctx context.Context, id string, quantity int, opts *CartAddOpts) (*CartContents, error)
 
 	// Remove removes a product entirely from the cart.
 	Remove(ctx context.Context, id string) (*CartContents, error)


### PR DESCRIPTION
Amazon cart additions always resolved the current buy-box offer, preventing callers from selecting an offer they already had. Add `shop cart add <ASIN> --offer-id '<offer-id>'` to pass the selected offer unchanged to Amazon and skip the product lookup. Omitting the flag retains buy-box selection; an explicitly blank flag is rejected.

The Go API now takes `Cart.Add(ctx, productID, quantity, opts)` with `*shop.CartAddOpts`. Existing Go callers must supply `nil` as the final argument for the default offer. The README and embedded shopping skill document both paths.

Validation: `go build ./...`, `go vet ./...`, and formatting passed. No tests or live Amazon cart operations were run.
