### PR TITLE
feat: full Amazon reviews with reliable pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,12 +250,16 @@ shop reviews B0D1XD1ZV3
 shop reviews B0D1XD1ZV3 --sort recent --rating 5 --page 2
 ```
 
+Amazon reviews combine full web review text, native review IDs, verified-purchase flags, helpful votes and available images with TVSS aggregate ratings. The aggregate describes all product ratings, not just the selected star filter. `reviews` is always an array; `hasMore` follows Amazon’s continuation state. A body ending in an ellipsis is marked `attributes.possiblyTruncated` rather than assumed complete.
+
+Pagination follows the live review feed, not a fixed snapshot: new reviews can shift pages between commands. Unexpected responses and repeated pages return errors instead of silently reporting an empty or duplicate page. Native review IDs replace the old synthesized IDs; consumers that persist review IDs should account for that change.
+
 <details>
 <summary><strong>Review flags</strong></summary>
 
-- `--sort` — `recent`, `helpful`, `rating`
+- `--sort` — `recent` or `helpful` for Amazon (`rating` is not supported)
 - `--rating` — Filter to specific star rating (1–5)
-- `--page` / `--page-size` — Pagination
+- `--page` / `--page-size` — Pages 1–100; page size 1–100 (default 10). Later pages follow Amazon’s continuation cursors and may take longer.
 
 </details>
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -101,7 +101,9 @@ shop reviews B0D1XD1ZV3
 shop reviews B0D1XD1ZV3 --sort recent --rating 5 --page 2
 ```
 
-Flags: `--sort` (recent|helpful|rating), `--rating` (1-5), `--page`, `--page-size`
+Flags: `--sort` (recent|helpful for Amazon), `--rating` (1-5), `--page` (1-100), `--page-size` (1-100, default 10).
+
+Review bodies use the full text supplied by Amazon. Preserve `attributes.possiblyTruncated` when present; do not call that body complete. Aggregate ratings are product-wide even when filtering reviews. Use `hasMore` to decide whether to request another page. Pagination follows a live feed and later pages take additional requests; errors are not evidence that a product has no reviews.
 
 ### Offers
 

--- a/internal/cli/reviews.go
+++ b/internal/cli/reviews.go
@@ -46,7 +46,7 @@ func (c *CLI) newReviewsCmd() *cobra.Command {
 	f := cmd.Flags()
 	f.IntVar(&page, "page", 1, "page number")
 	f.IntVar(&pageSize, "page-size", 0, "results per page")
-	f.StringVar(&sortBy, "sort", "", "sort: recent|helpful|rating")
+	f.StringVar(&sortBy, "sort", "", "sort: recent|helpful (provider-dependent)")
 	f.IntVar(&rating, "rating", 0, "filter to specific star rating (1-5)")
 
 	return cmd

--- a/internal/provider/amazon/reviews.go
+++ b/internal/provider/amazon/reviews.go
@@ -2,126 +2,209 @@ package amazon
 
 import (
 	"context"
-	"crypto/md5"
-	"fmt"
+	"encoding/json"
+	"io"
+	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/saucesteals/shop"
 )
 
-// Reviews fetches customer reviews for a product.
-//
-// TVSS endpoint: GET /marketplaces/{marketplace}/products/{asin}/customer-reviews
+// Reviews combines TVSS aggregate ratings with full web review text. Amazon's
+// web pagination is cursor-based; pageNumber alone silently repeats page one.
 func (s *Store) Reviews(ctx context.Context, productID string, opts *shop.ReviewsQuery) (*shop.ReviewsResult, error) {
 	if err := validateASIN(productID); err != nil {
 		return nil, err
 	}
-
+	q := shop.ReviewsQuery{}
+	if opts != nil {
+		q = *opts
+	}
+	if q.Page < 0 || q.PageSize < 0 || q.PageSize > 100 {
+		return nil, shop.Errorf(shop.ErrInvalidInput, "page must be positive and page-size must be between 1 and 100")
+	}
+	if q.Page == 0 {
+		q.Page = 1
+	}
+	if q.PageSize == 0 {
+		q.PageSize = 10
+	}
+	if q.Page > 100 {
+		return nil, shop.Errorf(shop.ErrInvalidInput, "Amazon reviews support pages 1–100")
+	}
+	if q.Rating != nil && (*q.Rating < 1 || *q.Rating > 5) {
+		return nil, shop.Errorf(shop.ErrInvalidInput, "rating must be between 1 and 5")
+	}
+	if q.Sort != "" && q.Sort != shop.ReviewSortHelpful && q.Sort != shop.ReviewSortRecent {
+		return nil, shop.Errorf(shop.ErrInvalidInput, "Amazon reviews support sort helpful or recent")
+	}
 	api, err := s.tvssAPI()
 	if err != nil {
 		return nil, err
 	}
-
-	if opts == nil {
-		opts = &shop.ReviewsQuery{}
-	}
-
-	pageSize := opts.PageSize
-	if pageSize <= 0 {
-		pageSize = 10
-	}
-
-	params := url.Values{}
-	params.Set("page-size", strconv.Itoa(pageSize))
-
-	if opts.Page > 1 {
-		params.Set("page-index", strconv.Itoa(opts.Page-1))
-	}
-
-	if opts.Rating != nil && *opts.Rating >= 1 && *opts.Rating <= 5 {
-		params.Set("stars", strconv.Itoa(*opts.Rating))
-	}
-
-	switch opts.Sort {
-	case shop.ReviewSortRecent:
-		params.Set("sort-by-type", "recent")
-	case shop.ReviewSortHelpful:
-		params.Set("sort-by-type", "helpful")
-	default:
-		// TVSS default is helpful
-	}
-
-	u := api.tvssPath([]string{"products", productID, "customer-reviews"}, params)
-
-	var resp tvssReviewsResponse
-	if err := api.doGet(ctx, u, &resp); err != nil {
+	base := "https://www." + s.handle
+	body, err := fetchReviewPage(ctx, api, base+"/product-reviews/"+productID+"/", nil, "")
+	if err != nil {
 		return nil, err
 	}
-
-	result := &shop.ReviewsResult{
-		Page:    opts.Page,
-		HasMore: resp.PageNext != "",
+	page, err := parseReviewPage(body)
+	if err != nil {
+		return nil, err
 	}
-	if result.Page < 1 {
-		result.Page = 1
+	endpoint, err := url.Parse(page.Endpoint)
+	if err != nil || endpoint == nil || endpoint.IsAbs() || endpoint.Host != "" || !strings.HasPrefix(endpoint.Path, "/portal/customer-reviews/ajax/") || strings.Contains(page.Endpoint, "\\") {
+		return nil, shop.Errorf(shop.ErrStoreError, "Amazon review pagination endpoint is missing or unsupported")
 	}
-
-	// Aggregate rating.
-	totalReviews := resp.OneStarCount + resp.TwoStarCount + resp.ThreeStarCount +
-		resp.FourStarCount + resp.FiveStarCount
-
-	result.Rating = shop.Rating{
-		Count: totalReviews,
+	if page.CSRF == "" {
+		return nil, shop.Errorf(shop.ErrStoreError, "Amazon review session is missing; log in again")
 	}
-
-	if resp.ProductStarRatings != nil {
-		result.Rating.Average = resp.ProductStarRatings.OverallAverageRating.Float64()
-		result.Rating.Count = resp.ProductStarRatings.Count
-		result.Rating.Stars = &shop.StarBreakdown{
-			Five:  resp.ProductStarRatings.FiveStarPercent.Float64(),
-			Four:  resp.ProductStarRatings.FourStarPercent.Float64(),
-			Three: resp.ProductStarRatings.ThreeStarPercent.Float64(),
-			Two:   resp.ProductStarRatings.TwoStarPercent.Float64(),
-			One:   resp.ProductStarRatings.OneStarPercent.Float64(),
-		}
+	result := &shop.ReviewsResult{Page: q.Page, Reviews: []shop.Review{}}
+	var aggregate tvssReviewsResponse
+	if err := api.doGet(ctx, api.tvssPath([]string{"products", productID, "customer-reviews"}, url.Values{"page-size": {"10"}}), &aggregate); err != nil {
+		return nil, err
 	}
-
-	// Map individual reviews.
-	for _, r := range resp.Reviews {
-		review := shop.Review{
-			Author: r.AuthorName,
-			Title:  r.Title,
-			Body:   r.Text,
-			Date:   r.SubmissionDate,
+	if r := aggregate.ProductStarRatings; r != nil {
+		result.Rating = shop.Rating{
+			Average: r.OverallAverageRating.Float64(),
+			Count:   r.Count,
+			Stars: &shop.StarBreakdown{
+				Five: r.FiveStarPercent.Float64(), Four: r.FourStarPercent.Float64(),
+				Three: r.ThreeStarPercent.Float64(), Two: r.TwoStarPercent.Float64(), One: r.OneStarPercent.Float64(),
+			},
 		}
-
-		// Generate a stable ID from author+title+date to reduce collisions
-		// (e.g., multiple "Five Stars" reviews from different authors).
-		review.ID = fmt.Sprintf("%x", md5.Sum([]byte(r.AuthorName+r.Title+r.SubmissionDate)))[:12]
-
-		if r.OverallRating != nil {
-			review.Rating = int(*r.OverallRating)
+	} else {
+		result.Rating.Count = aggregate.OneStarCount + aggregate.TwoStarCount + aggregate.ThreeStarCount + aggregate.FourStarCount + aggregate.FiveStarCount
+	}
+	params := url.Values{"asin": {productID}, "pageSize": {"10"}, "deviceType": {"mobile"}, "reviewerType": {"all_reviews"}, "sortBy": {"helpful"}, "filterByStar": {"all_stars"}}
+	if q.Sort != "" {
+		params.Set("sortBy", string(q.Sort))
+	}
+	if q.Rating != nil {
+		params.Set("filterByStar", []string{"", "one_star", "two_star", "three_star", "four_star", "five_star"}[*q.Rating])
+	}
+	// Expose stable-size CLI pages over Amazon’s native ten-review batches.
+	// Cursors are replayed per invocation, never persisted as account state.
+	start, end := (q.Page-1)*q.PageSize, q.Page*q.PageSize
+	seen := map[string]bool{}
+	position := 0
+	for batch := 1; position < end; batch++ {
+		params.Set("pageNumber", strconv.Itoa(batch))
+		body, err = fetchReviewPage(ctx, api, base+endpoint.String(), params, page.CSRF)
+		if err != nil {
+			return nil, err
 		}
-		if r.IsVerifiedPurchase != nil && *r.IsVerifiedPurchase {
-			review.Verified = true
+		fragment, err := decodeReviewStream(body)
+		if err != nil {
+			return nil, err
 		}
-
-		for _, img := range r.ImageURLs {
-			u := img.LargeImageURL
-			if u == "" {
-				u = img.MediumImageURL
+		current, err := parseReviewPage(fragment)
+		if err != nil {
+			return nil, err
+		}
+		for _, review := range current.Reviews {
+			if seen[review.ID] {
+				return nil, shop.Errorf(shop.ErrStoreError, "Amazon repeated a review page; pagination could not be verified")
 			}
-			if u == "" {
-				u = img.SmallImageURL
+			seen[review.ID] = true
+			if position >= start && position < end {
+				result.Reviews = append(result.Reviews, review)
 			}
-			if u != "" {
-				review.Images = append(review.Images, shop.Image{URL: u})
-			}
+			position++
 		}
-
-		result.Reviews = append(result.Reviews, review)
+		result.HasMore = position > end || current.Next != ""
+		if current.Next == "" {
+			break
+		}
+		if len(current.Reviews) == 0 || current.Next == params.Get("nextPageToken") {
+			return nil, shop.Errorf(shop.ErrStoreError, "Amazon review pagination made no progress")
+		}
+		params.Set("nextPageToken", current.Next)
 	}
-
 	return result, nil
+}
+
+// fetchReviewPage never includes remote bodies or session values in errors.
+func fetchReviewPage(ctx context.Context, api *tvssClient, target string, form url.Values, csrf string) ([]byte, error) {
+	method := http.MethodGet
+	var reader io.Reader
+	if form != nil {
+		method = http.MethodPost
+		reader = strings.NewReader(form.Encode())
+	}
+	req, err := api.newRequest(ctx, method, target, reader)
+	if err != nil {
+		return nil, shop.Errorf(shop.ErrInternal, "build reviews request")
+	}
+	req.Header.Set("User-Agent", mobileUA)
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	req.Header.Set("Accept", "text/html")
+	if form != nil {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
+		req.Header.Set("X-Requested-With", "XMLHttpRequest")
+		req.Header.Set("anti-csrftoken-a2z", csrf)
+	}
+	client := *api.http
+	client.CheckRedirect = func(r *http.Request, via []*http.Request) error {
+		if r.URL.Scheme != "https" || r.URL.Host != req.URL.Host || strings.HasPrefix(r.URL.Path, "/ap/") {
+			return http.ErrUseLastResponse
+		}
+		if len(via) >= 5 {
+			return http.ErrUseLastResponse
+		}
+		return nil
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, shop.Errorf(shop.ErrNetwork, "reviews request failed")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		return nil, shop.Errorf(shop.ErrAuthExpired, "Amazon reviews require a valid session; log in again")
+	}
+	if resp.StatusCode != 200 {
+		return nil, shop.Errorf(shop.ErrStoreError, "Amazon reviews returned HTTP %d", resp.StatusCode)
+	}
+	const maxBody = 8 << 20
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
+	if err != nil {
+		return nil, shop.Errorf(shop.ErrNetwork, "read reviews response")
+	}
+	if len(body) > maxBody {
+		return nil, shop.Errorf(shop.ErrStoreError, "Amazon reviews response exceeded size limit")
+	}
+	return body, nil
+}
+
+func decodeReviewStream(body []byte) ([]byte, error) {
+	var out strings.Builder
+	loaded := false
+	for _, part := range strings.Split(string(body), "&&&") {
+		if strings.TrimSpace(part) == "" {
+			continue
+		}
+		var chunk []json.RawMessage
+		if json.Unmarshal([]byte(part), &chunk) != nil || len(chunk) == 0 {
+			return nil, shop.Errorf(shop.ErrStoreError, "unexpected Amazon reviews response")
+		}
+		var op string
+		_ = json.Unmarshal(chunk[0], &op)
+		if op == "loaded" {
+			loaded = true
+		}
+		if (op == "append" || op == "update") && len(chunk) == 3 {
+			var selector, markup string
+			if json.Unmarshal(chunk[1], &selector) != nil || json.Unmarshal(chunk[2], &markup) != nil {
+				return nil, shop.Errorf(shop.ErrStoreError, "invalid Amazon reviews fragment")
+			}
+			if selector == "#cm_cr-review_list" || selector == "#reviews-pagination" {
+				out.WriteString(markup)
+			}
+		}
+	}
+	if !loaded {
+		return nil, shop.Errorf(shop.ErrStoreError, "Amazon did not confirm review loading")
+	}
+	return []byte(out.String()), nil
 }

--- a/internal/provider/amazon/reviews.go
+++ b/internal/provider/amazon/reviews.go
@@ -177,9 +177,11 @@ func fetchReviewPage(ctx context.Context, api *tvssClient, target string, form u
 	return body, nil
 }
 
+// A loaded event precedes the content and is not completion. Require a
+// review-list operation followed by pagination, including explicit empty pages.
 func decodeReviewStream(body []byte) ([]byte, error) {
-	var out strings.Builder
-	loaded := false
+	var list, pagination strings.Builder
+	listSeen, paginationSeen := false, false
 	for _, part := range strings.Split(string(body), "&&&") {
 		if strings.TrimSpace(part) == "" {
 			continue
@@ -189,22 +191,40 @@ func decodeReviewStream(body []byte) ([]byte, error) {
 			return nil, shop.Errorf(shop.ErrStoreError, "unexpected Amazon reviews response")
 		}
 		var op string
-		_ = json.Unmarshal(chunk[0], &op)
-		if op == "loaded" {
-			loaded = true
+		if json.Unmarshal(chunk[0], &op) != nil {
+			return nil, shop.Errorf(shop.ErrStoreError, "invalid Amazon reviews operation")
 		}
-		if (op == "append" || op == "update") && len(chunk) == 3 {
-			var selector, markup string
-			if json.Unmarshal(chunk[1], &selector) != nil || json.Unmarshal(chunk[2], &markup) != nil {
-				return nil, shop.Errorf(shop.ErrStoreError, "invalid Amazon reviews fragment")
+		if op != "append" && op != "update" {
+			if op == "loaded" {
+				continue
 			}
-			if selector == "#cm_cr-review_list" || selector == "#reviews-pagination" {
-				out.WriteString(markup)
+			return nil, shop.Errorf(shop.ErrStoreError, "unsupported Amazon reviews operation")
+		}
+		if len(chunk) != 3 {
+			return nil, shop.Errorf(shop.ErrStoreError, "invalid Amazon reviews fragment")
+		}
+		var selector, markup string
+		if json.Unmarshal(chunk[1], &selector) != nil || json.Unmarshal(chunk[2], &markup) != nil {
+			return nil, shop.Errorf(shop.ErrStoreError, "invalid Amazon reviews fragment")
+		}
+		switch selector {
+		case "#cm_cr-review_list":
+			if op == "update" {
+				list.Reset()
 			}
+			list.WriteString(markup)
+			listSeen = true
+			paginationSeen = false
+		case "#reviews-pagination", "#cm_cr-pagination_bar":
+			if op == "update" {
+				pagination.Reset()
+			}
+			pagination.WriteString(markup)
+			paginationSeen = listSeen
 		}
 	}
-	if !loaded {
-		return nil, shop.Errorf(shop.ErrStoreError, "Amazon did not confirm review loading")
+	if !listSeen || !paginationSeen {
+		return nil, shop.Errorf(shop.ErrStoreError, "Amazon review response ended before content and pagination were complete")
 	}
-	return []byte(out.String()), nil
+	return []byte(list.String() + pagination.String()), nil
 }

--- a/internal/provider/amazon/reviews_parser.go
+++ b/internal/provider/amazon/reviews_parser.go
@@ -48,13 +48,17 @@ func parseReviewPage(body []byte) (*reviewPage, error) {
 		var state struct {
 			Next string `json:"nextPageToken"`
 		}
-		if json.Unmarshal([]byte(reviewAttr(n, "data-reviews-state-param")), &state) == nil {
-			p.Next = state.Next
+		if json.Unmarshal([]byte(reviewAttr(n, "data-reviews-state-param")), &state) != nil || strings.TrimSpace(state.Next) == "" {
+			return nil, shop.Errorf(shop.ErrStoreError, "Amazon show-more control is missing valid continuation state")
 		}
+		p.Next = state.Next
 	}
 	nodes := reviewFind(doc, "data-hook", "mobley-review-content")
 	if len(nodes) == 0 {
 		nodes = reviewFind(doc, "data-hook", "review")
+	}
+	if len(nodes) == 0 && !strings.Contains(reviewText(doc), "Sorry, no reviews match your current selections.") {
+		return nil, shop.Errorf(shop.ErrStoreError, "Amazon returned unrecognized review content, not a confirmed empty result")
 	}
 	for _, n := range nodes {
 		r := shop.Review{ID: reviewAttr(n, "id"), Author: reviewFirstText(n, "class", "a-profile-name"), Title: reviewFirstText(n, "data-hook", "review-title"), Date: reviewFirstText(n, "data-hook", "review-date")}

--- a/internal/provider/amazon/reviews_parser.go
+++ b/internal/provider/amazon/reviews_parser.go
@@ -1,0 +1,190 @@
+package amazon
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/saucesteals/shop"
+	"golang.org/x/net/html"
+)
+
+type reviewPage struct {
+	Reviews  []shop.Review
+	Endpoint string
+	CSRF     string
+	Next     string
+}
+
+// Amazon embeds review-session settings in inline state. Decode JSON string
+// values, not JavaScript, and keep all session material internal.
+var reviewStateField = regexp.MustCompile(`"(reviewsAjaxUrl|reviewsCsrfToken)"\s*:\s*("(?:\\.|[^"\\])*")`)
+var reviewStars = regexp.MustCompile(`a-star-(?:small-)?([1-5])(?:\s|$)`)
+var reviewHelpfulCount = regexp.MustCompile(`[\d,]+`)
+
+func parseReviewPage(body []byte) (*reviewPage, error) {
+	doc, err := html.Parse(bytes.NewReader(body))
+	if err != nil {
+		return nil, shop.Errorf(shop.ErrStoreError, "parse Amazon reviews")
+	}
+	p := &reviewPage{Reviews: []shop.Review{}}
+	for _, m := range reviewStateField.FindAllSubmatch(body, -1) {
+		var value string
+		if json.Unmarshal(m[2], &value) != nil {
+			continue
+		}
+		switch string(m[1]) {
+		case "reviewsAjaxUrl":
+			p.Endpoint = value
+		case "reviewsCsrfToken":
+			p.CSRF = value
+		}
+	}
+	for _, n := range reviewFind(doc, "data-hook", "show-more-button") {
+		var state struct {
+			Next string `json:"nextPageToken"`
+		}
+		if json.Unmarshal([]byte(reviewAttr(n, "data-reviews-state-param")), &state) == nil {
+			p.Next = state.Next
+		}
+	}
+	nodes := reviewFind(doc, "data-hook", "mobley-review-content")
+	if len(nodes) == 0 {
+		nodes = reviewFind(doc, "data-hook", "review")
+	}
+	for _, n := range nodes {
+		r := shop.Review{ID: reviewAttr(n, "id"), Author: reviewFirstText(n, "class", "a-profile-name"), Title: reviewFirstText(n, "data-hook", "review-title"), Date: reviewFirstText(n, "data-hook", "review-date")}
+		// Mobile pages contain a shortened copy followed by the full hidden body.
+		// Choose the fullest body, preserving line breaks rather than UI controls.
+		for _, b := range reviewFind(n, "data-hook", "review-body") {
+			if text := reviewText(b); len(text) > len(r.Body) {
+				r.Body = text
+			}
+		}
+		for _, hook := range []string{"review-star-rating", "cmps-review-star-rating"} {
+			for _, star := range reviewFind(n, "data-hook", hook) {
+				if m := reviewStars.FindStringSubmatch(reviewAttr(star, "class")); m != nil {
+					r.Rating, _ = strconv.Atoi(m[1])
+				}
+				// Desktop review titles nest the star label alongside the actual title.
+				label := reviewText(star)
+				r.Title = strings.TrimSpace(strings.TrimPrefix(r.Title, label))
+			}
+		}
+		r.Verified = len(reviewFind(n, "data-hook", "avp-badge"))+len(reviewFind(n, "data-hook", "msrp-avp-badge-linkless")) > 0
+		helpful := reviewFirstText(n, "data-hook", "helpful-vote-statement")
+		if strings.HasPrefix(helpful, "One person") {
+			r.Helpful = 1
+		} else if count := reviewHelpfulCount.FindString(helpful); count != "" {
+			r.Helpful, _ = strconv.Atoi(strings.ReplaceAll(count, ",", ""))
+		}
+		imageSeen := map[string]bool{}
+		for _, hook := range []string{"review-image-tile", "review-image-tile-section"} {
+			for _, tile := range reviewFind(n, "data-hook", hook) {
+				for _, img := range reviewElements(tile, "img") {
+					u := reviewAttr(img, "src")
+					if strings.HasPrefix(u, "https://") && !imageSeen[u] {
+						r.Images = append(r.Images, shop.Image{URL: u})
+						imageSeen[u] = true
+					}
+				}
+			}
+		}
+		if r.Body == "" || r.Rating == 0 {
+			return nil, shop.Errorf(shop.ErrStoreError, "Amazon review is missing text or rating; page format may have changed")
+		}
+		if strings.HasSuffix(r.Body, "...") || strings.HasSuffix(r.Body, "…") {
+			r.Attributes = map[string]any{"possiblyTruncated": true}
+		}
+		if r.ID == "" {
+			r.ID = fmt.Sprintf("%x", sha256.Sum256([]byte(r.Author+"\x00"+r.Title+"\x00"+r.Date)))[:24]
+		}
+		p.Reviews = append(p.Reviews, r)
+	}
+	return p, nil
+}
+
+func reviewAttr(n *html.Node, key string) string {
+	for _, a := range n.Attr {
+		if a.Key == key {
+			return a.Val
+		}
+	}
+	return ""
+}
+func reviewFind(n *html.Node, key, value string) []*html.Node {
+	var found []*html.Node
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		v := reviewAttr(n, key)
+		match := v == value
+		if key == "class" {
+			match = false
+			for _, c := range strings.Fields(v) {
+				if c == value {
+					match = true
+					break
+				}
+			}
+		}
+		if n.Type == html.ElementNode && match {
+			found = append(found, n)
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(n)
+	return found
+}
+func reviewElements(n *html.Node, tag string) []*html.Node {
+	var found []*html.Node
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == tag {
+			found = append(found, n)
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(n)
+	return found
+}
+func reviewFirstText(n *html.Node, key, value string) string {
+	nodes := reviewFind(n, key, value)
+	if len(nodes) > 0 {
+		return reviewText(nodes[0])
+	}
+	return ""
+}
+func reviewText(n *html.Node) string {
+	var b strings.Builder
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && (n.Data == "script" || n.Data == "style") {
+			return
+		}
+		if n.Type == html.TextNode {
+			b.WriteString(n.Data)
+		}
+		if n.Type == html.ElementNode && n.Data == "br" {
+			b.WriteByte('\n')
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(n)
+	var lines []string
+	for _, line := range strings.Split(b.String(), "\n") {
+		if line = strings.Join(strings.Fields(line), " "); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
## Summary
Add working Amazon review text to the existing TVSS-backed CLI. This is a reviews-only change: no Android/AAPI transport, new dependencies, product/search changes, cart changes, or checkout changes.

- Fetch full mobile review bodies instead of the shortened duplicate nodes.
- Follow the review AJAX endpoint and returned continuation cursor; `pageNumber` alone repeats page one.
- Keep TVSS aggregate average/count/star distribution alongside web review text, native IDs, verified flags, helpful votes and supported image markup.
- Implement requested page sizes over Amazon's ten-review batches, with repeated-page/no-progress detection.
- Reject invalid/unsupported options explicitly; update CLI help, README and embedded agent guidance.
- Bound response sizes and redirects; keep session state and remote response bodies out of new transport errors.

## Live verification
Built and ran against three ASINs: B0CZ43567W, B0D4Z9RPT8, B0CPHWJ31Q.

- Each returns 10 written reviews with nonzero aggregate ratings (original returned zero written reviews).
- Full bodies observed up to 4,150 characters, rather than ~250-character snippets.
- Pages 1/2 have zero review-ID overlap; `hasMore` is true.
- Recent sort verified descending by review date; one-star filter returns only one-star reviews.
- Page size 3 / page 2 matches the corresponding slice of the ten-review page.
- Invalid star filter, unsupported rating sort and oversized page size return `invalid_input`.
- `go build`, `go vet ./...`, and `git diff --check` pass. No new tests added.
- No cart mutations, checkout or order placement performed.

## Compatibility / limits
Existing JSON fields are retained. Native review IDs replace synthesized IDs. Aggregate ratings remain product-wide, even with a review filter. Possible remaining ellipsis truncation is marked in `attributes.possiblyTruncated`. Pages follow a live feed, not a fixed snapshot; later pages replay cursors and may need a longer timeout. Review image extraction is implemented but not established by the sampled mobile reviews. Non-US marketplaces were not live-tested.
