### PR TITLE
feat: support all offers and selected-offer carts

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,12 +285,19 @@ Returns seller offers for a product, including condition and pricing.
 ```bash
 shop cart add B0D1XD1ZV3              # Add 1 unit
 shop cart add B0D1XD1ZV3 --qty 3     # Add 3 units
+shop cart add B0D1XD1ZV3 --offer '<offer-id>' # Add a specific offer returned by `shop offers`
 shop cart view                        # View cart with subtotal
 shop cart remove B0D1XD1ZV3           # Remove item
 shop cart clear                       # Empty the cart
 ```
 
 All cart commands return the full cart snapshot with items and subtotal.
+
+`--offer` is provider-neutral: pass an offer ID returned by `shop offers` for
+the same product. Omit it to let the store choose its default offer.
+
+Go callers can pass `&shop.CartAddOptions{OfferID: offerID}` to select an
+offer, or `nil` to use the provider-selected default.
 
 ### Checkout & Order
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -119,12 +119,15 @@ Flags: `--condition` (new|used_like_new|used_good|used_fair|refurbished), `--pag
 ```bash
 shop cart add B0D1XD1ZV3             # add 1 unit
 shop cart add B0D1XD1ZV3 --qty 3     # add 3
+shop cart add B0D1XD1ZV3 --offer '<offer-id>' # add a specific result from `shop offers`
 shop cart view                        # view cart
 shop cart remove B0D1XD1ZV3           # remove item
 shop cart clear                       # empty cart
 ```
 
 All cart commands return full cart snapshot: `.items[]` (product + quantity) and `.subtotal`.
+`--offer` accepts a provider-neutral offer ID returned by `shop offers` for the
+same product. Omit it to use the provider-selected default offer.
 
 ### Checkout (preview only)
 

--- a/amazon/amazon.go
+++ b/amazon/amazon.go
@@ -1,0 +1,4 @@
+// Package amazon registers the Amazon shop provider.
+package amazon
+
+import _ "github.com/saucesteals/shop/internal/provider/amazon"

--- a/internal/cli/cart.go
+++ b/internal/cli/cart.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	"github.com/saucesteals/shop"
@@ -23,7 +25,10 @@ func (c *CLI) newCartCmd() *cobra.Command {
 }
 
 func (c *CLI) newCartAddCmd() *cobra.Command {
-	var qty int
+	var (
+		qty     int
+		offerID string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "add <product-id>",
@@ -33,6 +38,9 @@ func (c *CLI) newCartAddCmd() *cobra.Command {
 			if qty < 1 {
 				return shop.Errorf(shop.ErrInvalidInput, "quantity must be >= 1, got %d", qty)
 			}
+			if cmd.Flags().Changed("offer") && strings.TrimSpace(offerID) == "" {
+				return shop.Errorf(shop.ErrInvalidInput, "offer must not be empty")
+			}
 
 			ctx, cancel, s, err := c.resolveStore(cmd)
 			if err != nil {
@@ -40,7 +48,10 @@ func (c *CLI) newCartAddCmd() *cobra.Command {
 			}
 			defer cancel()
 
-			result, err := s.Cart().Add(ctx, args[0], qty)
+			options := &shop.CartAddOptions{
+				OfferID: offerID,
+			}
+			result, err := s.Cart().Add(ctx, args[0], qty, options)
 			if err != nil {
 				return err
 			}
@@ -49,7 +60,9 @@ func (c *CLI) newCartAddCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().IntVar(&qty, "qty", 1, "quantity to add")
+	flags := cmd.Flags()
+	flags.IntVar(&qty, "qty", 1, "quantity to add")
+	flags.StringVar(&offerID, "offer", "", "offer ID returned by the offers command (defaults to the provider-selected offer)")
 
 	return cmd
 }

--- a/internal/provider/amazon/amazon.go
+++ b/internal/provider/amazon/amazon.go
@@ -82,6 +82,7 @@ func (p *Provider) Store(_ context.Context, handle string, configDir string) (sh
 		handle:        handle,
 		configDir:     configDir,
 		client:        &http.Client{Timeout: httpTimeout},
+		offersClient:  newOffersHTTPClient(),
 		currency:      info.Currency,
 		marketplaceID: info.MarketplaceID,
 	}
@@ -95,12 +96,25 @@ type Store struct {
 	handle        string
 	configDir     string
 	client        *http.Client
+	offersClient  *http.Client
 	cart          *cartImpl
 	currency      string
 	marketplaceID string
 
 	mu   sync.Mutex
 	tvss *tvssClient
+}
+
+func newOffersHTTPClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	// Amazon's AOD endpoint rejects the automatic Accept-Encoding header sent
+	// by Go's default transport. Disable negotiation so the header is omitted.
+	transport.DisableCompression = true
+
+	return &http.Client{
+		Transport: transport,
+		Timeout:   httpTimeout,
+	}
 }
 
 // tvssAPI returns the tvssClient, initializing it from auth state on first

--- a/internal/provider/amazon/amazon.go
+++ b/internal/provider/amazon/amazon.go
@@ -77,16 +77,17 @@ func (p *Provider) DetectCost() shop.DetectCost { return shop.DetectCostFree }
 // Store creates an Amazon Store instance. configDir is used for auth file I/O.
 func (p *Provider) Store(_ context.Context, handle string, configDir string) (shop.Store, error) {
 	info := supportedDomains[handle]
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.DisableCompression = true
+	aodTransport := http.DefaultTransport.(*http.Transport).Clone()
+	// AOD behaves inconsistently when Go injects Accept-Encoding. Keep this
+	// exception isolated so every other Amazon request retains normal transport
+	// behavior and automatic compression.
+	aodTransport.DisableCompression = true
 
 	s := &Store{
-		handle:    handle,
-		configDir: configDir,
-		client: &http.Client{
-			Transport: &decodingTransport{base: transport},
-			Timeout:   httpTimeout,
-		},
+		handle:        handle,
+		configDir:     configDir,
+		client:        &http.Client{Timeout: httpTimeout},
+		aodClient:     &http.Client{Transport: aodTransport, Timeout: httpTimeout},
 		currency:      info.Currency,
 		marketplaceID: info.MarketplaceID,
 	}
@@ -100,6 +101,7 @@ type Store struct {
 	handle        string
 	configDir     string
 	client        *http.Client
+	aodClient     *http.Client
 	cart          *cartImpl
 	currency      string
 	marketplaceID string

--- a/internal/provider/amazon/amazon.go
+++ b/internal/provider/amazon/amazon.go
@@ -77,12 +77,16 @@ func (p *Provider) DetectCost() shop.DetectCost { return shop.DetectCostFree }
 // Store creates an Amazon Store instance. configDir is used for auth file I/O.
 func (p *Provider) Store(_ context.Context, handle string, configDir string) (shop.Store, error) {
 	info := supportedDomains[handle]
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DisableCompression = true
 
 	s := &Store{
-		handle:        handle,
-		configDir:     configDir,
-		client:        &http.Client{Timeout: httpTimeout},
-		offersClient:  newOffersHTTPClient(),
+		handle:    handle,
+		configDir: configDir,
+		client: &http.Client{
+			Transport: &decodingTransport{base: transport},
+			Timeout:   httpTimeout,
+		},
 		currency:      info.Currency,
 		marketplaceID: info.MarketplaceID,
 	}
@@ -96,25 +100,12 @@ type Store struct {
 	handle        string
 	configDir     string
 	client        *http.Client
-	offersClient  *http.Client
 	cart          *cartImpl
 	currency      string
 	marketplaceID string
 
 	mu   sync.Mutex
 	tvss *tvssClient
-}
-
-func newOffersHTTPClient() *http.Client {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	// Amazon's AOD endpoint rejects the automatic Accept-Encoding header sent
-	// by Go's default transport. Disable negotiation so the header is omitted.
-	transport.DisableCompression = true
-
-	return &http.Client{
-		Transport: transport,
-		Timeout:   httpTimeout,
-	}
 }
 
 // tvssAPI returns the tvssClient, initializing it from auth state on first

--- a/internal/provider/amazon/amazon.go
+++ b/internal/provider/amazon/amazon.go
@@ -4,7 +4,6 @@ package amazon
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"sync"
 	"time"
 
@@ -77,17 +76,11 @@ func (p *Provider) DetectCost() shop.DetectCost { return shop.DetectCostFree }
 // Store creates an Amazon Store instance. configDir is used for auth file I/O.
 func (p *Provider) Store(_ context.Context, handle string, configDir string) (shop.Store, error) {
 	info := supportedDomains[handle]
-	aodTransport := http.DefaultTransport.(*http.Transport).Clone()
-	// AOD behaves inconsistently when Go injects Accept-Encoding. Keep this
-	// exception isolated so every other Amazon request retains normal transport
-	// behavior and automatic compression.
-	aodTransport.DisableCompression = true
 
 	s := &Store{
 		handle:        handle,
 		configDir:     configDir,
-		client:        &http.Client{Timeout: httpTimeout},
-		aodClient:     &http.Client{Transport: aodTransport, Timeout: httpTimeout},
+		client:        newAmazonClient(),
 		currency:      info.Currency,
 		marketplaceID: info.MarketplaceID,
 	}
@@ -100,8 +93,7 @@ func (p *Provider) Store(_ context.Context, handle string, configDir string) (sh
 type Store struct {
 	handle        string
 	configDir     string
-	client        *http.Client
-	aodClient     *http.Client
+	client        *amazonClient
 	cart          *cartImpl
 	currency      string
 	marketplaceID string

--- a/internal/provider/amazon/auth.go
+++ b/internal/provider/amazon/auth.go
@@ -36,10 +36,10 @@ type authState struct {
 	CustomerID        string       `json:"customerId,omitempty"`
 	Cookies           []authCookie `json:"cookies,omitempty"`
 	CookiesExpiry     string       `json:"cookiesExpiry,omitempty"`
-	RefreshToken      string   `json:"refreshToken,omitempty"`
-	BearerToken       string   `json:"bearerToken,omitempty"`
-	BearerTokenExpiry string   `json:"bearerTokenExpiry,omitempty"`
-	AuthenticatedAt   string   `json:"authenticatedAt,omitempty"`
+	RefreshToken      string       `json:"refreshToken,omitempty"`
+	BearerToken       string       `json:"bearerToken,omitempty"`
+	BearerTokenExpiry string       `json:"bearerTokenExpiry,omitempty"`
+	AuthenticatedAt   string       `json:"authenticatedAt,omitempty"`
 }
 
 // authCookie is the JSON-serialized form of a single Amazon session cookie.
@@ -304,15 +304,10 @@ type alexaProfile struct {
 // treat this as best-effort enrichment.
 func (s *Store) fetchAlexaProfile(ctx context.Context, api *tvssClient) (*alexaProfile, error) {
 	alexaURL := fmt.Sprintf("https://alexa.%s/api/users/me", s.handle)
-	req, err := api.newRequest(ctx, http.MethodGet, alexaURL, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("User-Agent", mobileUA)
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := api.http.Do(req)
+	resp, err := api.http.do(ctx, http.MethodGet, alexaURL, nil, requestOptions{
+		profile: profileJSON,
+		cookies: api.cookies,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/amazon/cart.go
+++ b/internal/provider/amazon/cart.go
@@ -2,6 +2,7 @@ package amazon
 
 import (
 	"context"
+	"strings"
 
 	"github.com/saucesteals/shop"
 )
@@ -11,11 +12,11 @@ type cartImpl struct {
 	store *Store
 }
 
-// Add adds an item to the Amazon cart.
+// Add adds an item to the Amazon cart using the selected or buy-box offer.
 //
 // TVSS endpoint: PUT /marketplaces/{marketplace}/cart/items
 // Content-Type: application/vnd.com.amazon.tvss.api+json; type="cart.add.request/v1"
-func (c *cartImpl) Add(ctx context.Context, id string, quantity int) (*shop.CartContents, error) {
+func (c *cartImpl) Add(ctx context.Context, id string, quantity int, options *shop.CartAddOptions) (*shop.CartContents, error) {
 	if err := validateASIN(id); err != nil {
 		return nil, err
 	}
@@ -29,26 +30,32 @@ func (c *cartImpl) Add(ctx context.Context, id string, quantity int) (*shop.Cart
 		quantity = 1
 	}
 
-	// Fetch the offerId from the product detail. TVSS requires it.
-	prodURL := api.tvssPath([]string{"products", id}, nil)
-
-	var tp tvssProduct
-	if err := api.doGet(ctx, prodURL, &tp); err != nil {
-		return nil, shop.Errorf(shop.ErrNotFound, "product %s: %v", id, err)
+	offerID := ""
+	if options != nil {
+		offerID = strings.TrimSpace(options.OfferID)
 	}
 
-	if tp.OfferID == "" {
-		// Product exists in the catalog but has no current offer. This
-		// commonly happens when the product is out of stock in TVSS or
-		// the device type doesn't expose pricing.
-		return nil, shop.Errorf(shop.ErrOutOfStock, "product %s has no available offer", id)
+	if offerID == "" {
+		// TVSS requires an offer ID, so resolve the provider-selected offer
+		// only when the caller did not select one.
+		prodURL := api.tvssPath([]string{"products", id}, nil)
+
+		var tp tvssProduct
+		if err := api.doGet(ctx, prodURL, &tp); err != nil {
+			return nil, shop.Errorf(shop.ErrNotFound, "product %s: %v", id, err)
+		}
+		if tp.OfferID == "" {
+			return nil, shop.Errorf(shop.ErrOutOfStock, "product %s has no available offer", id)
+		}
+
+		offerID = tp.OfferID
 	}
 
 	req := tvssAddToCartRequest{
 		Items: []tvssAddToCartItem{
 			{
 				ASIN:     id,
-				OfferID:  tp.OfferID,
+				OfferID:  offerID,
 				Quantity: quantity,
 			},
 		},

--- a/internal/provider/amazon/client.go
+++ b/internal/provider/amazon/client.go
@@ -2,6 +2,7 @@ package amazon
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -30,6 +31,132 @@ func validateASIN(id string) error {
 	return nil
 }
 
+type requestProfile uint8
+
+const (
+	profileWeb requestProfile = iota
+	profileAOD
+	profileJSON
+	profileTVSS
+)
+
+type requestOptions struct {
+	profile       requestProfile
+	cookies       []*http.Cookie
+	headers       http.Header
+	checkRedirect func(*http.Request, []*http.Request) error
+}
+
+// amazonClient owns Amazon's shared HTTP request lifecycle.
+type amazonClient struct {
+	http *http.Client
+}
+
+// newAmazonClient creates the provider's canonical HTTP client.
+func newAmazonClient() *amazonClient {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DisableCompression = true
+
+	return &amazonClient{
+		http: &http.Client{
+			Transport: transport,
+			Timeout:   httpTimeout,
+		},
+	}
+}
+
+// do builds and sends an Amazon request with consistent defaults, cookies,
+// compression handling, and optional redirect policy.
+func (c *amazonClient) do(ctx context.Context, method, rawURL string, body io.Reader, opts requestOptions) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	applyRequestProfile(req, opts.profile)
+	for key, values := range opts.headers {
+		req.Header.Del(key)
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	for _, cookie := range opts.cookies {
+		req.AddCookie(cookie)
+	}
+
+	client := c.http
+	if opts.checkRedirect != nil {
+		clone := *c.http
+		clone.CheckRedirect = opts.checkRedirect
+		client = &clone
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if err := decodeGzip(resp); err != nil {
+		_ = resp.Body.Close()
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func applyRequestProfile(req *http.Request, profile requestProfile) {
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	switch profile {
+	case profileWeb:
+		req.Header.Set("User-Agent", mobileUA)
+		req.Header.Set("Accept", "text/html")
+	case profileAOD:
+		req.Header.Set("User-Agent", mobileUA)
+		req.Header.Set("Accept", "text/html")
+		req.Header.Del("Accept-Encoding")
+	case profileJSON:
+		req.Header.Set("User-Agent", mobileUA)
+		req.Header.Set("Accept", "application/json")
+	case profileTVSS:
+	}
+}
+
+func decodeGzip(resp *http.Response) error {
+	switch strings.ToLower(strings.TrimSpace(resp.Header.Get("Content-Encoding"))) {
+	case "", "identity":
+		return nil
+	case "gzip":
+		decoded, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return fmt.Errorf("decode gzip response: %w", err)
+		}
+		resp.Body = &gzipBody{Reader: decoded, compressed: resp.Body}
+		resp.Header.Del("Content-Encoding")
+		resp.Header.Del("Content-Length")
+		resp.ContentLength = -1
+		resp.Uncompressed = true
+		return nil
+	default:
+		return fmt.Errorf("unsupported content encoding %q", resp.Header.Get("Content-Encoding"))
+	}
+}
+
+type gzipBody struct {
+	*gzip.Reader
+	compressed io.Closer
+}
+
+func (b *gzipBody) Close() error {
+	decodeErr := b.Reader.Close()
+	compressedErr := b.compressed.Close()
+	if decodeErr != nil {
+		return decodeErr
+	}
+
+	return compressedErr
+}
+
 const tvssBaseURL = "https://tvss.amazon.com"
 
 // tvssClient wraps an http.Client with the auth state needed for TVSS API
@@ -39,7 +166,7 @@ const tvssBaseURL = "https://tvss.amazon.com"
 // Cookies, the access token, marketplace ID, and device UDID are
 // pre-computed at construction and reused for every request.
 type tvssClient struct {
-	http          *http.Client
+	http          *amazonClient
 	state         *authState
 	cookies       []*http.Cookie // standard cookies for AddCookie
 	accessToken   string         // at-main Atza token for x-amz-access-token header
@@ -50,7 +177,7 @@ type tvssClient struct {
 // newTVSSClient creates a tvssClient from the store's auth state.
 // Pre-computes the cookie list, extracts the access token, and uses the
 // device serial from registration as the stable UDID.
-func newTVSSClient(httpClient *http.Client, state *authState, marketplaceID string) *tvssClient {
+func newTVSSClient(httpClient *amazonClient, state *authState, marketplaceID string) *tvssClient {
 	return &tvssClient{
 		http:          httpClient,
 		state:         state,
@@ -80,57 +207,38 @@ func (c *tvssClient) tvssPath(segments []string, params url.Values) string {
 	return u + "?" + params.Encode()
 }
 
-// newRequest creates an http.Request with session cookies already applied.
-// All request paths (TVSS, web search, Alexa) use this as their starting
-// point instead of manually looping over cookies.
-func (c *tvssClient) newRequest(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
-	req, err := http.NewRequestWithContext(ctx, method, url, body)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, cookie := range c.cookies {
-		req.AddCookie(cookie)
-	}
-
-	return req, nil
-}
-
-// setTVSSHeaders applies TVSS-specific request headers (user agent, request
-// ID, app ID, access token). Does NOT apply cookies — those are set by
-// newRequest.
-func (c *tvssClient) setTVSSHeaders(req *http.Request) {
+// headers returns the canonical headers for TVSS requests.
+func (c *tvssClient) headers() http.Header {
 	b := make([]byte, 10)
 	_, _ = rand.Read(b)
 	requestID := strings.ToUpper(hex.EncodeToString(b))
 
-	req.Header.Set("x-amzn-RequestId", requestID)
-	req.Header.Set("User-Agent", tvssUA)
-	req.Header.Set("x-amz-msh-appid", fmt.Sprintf(
+	headers := make(http.Header)
+	headers.Set("x-amzn-RequestId", requestID)
+	headers.Set("User-Agent", tvssUA)
+	headers.Set("x-amz-msh-appid", fmt.Sprintf(
 		"name=ShopTV3P;ver=2000610;device=AFTMM;os=Android_7.1.2;UDID=%s;tag=mshop-amazon-us-20",
 		c.udid,
 	))
 
 	if c.accessToken != "" {
-		req.Header.Set("x-amz-access-token", c.accessToken)
+		headers.Set("x-amz-access-token", c.accessToken)
 	}
+
+	return headers
 }
 
 // doGet performs an authenticated GET against the TVSS API and unmarshals
 // the response into dest. acceptType is optional.
 func (c *tvssClient) doGet(ctx context.Context, rawURL string, dest any, headers ...map[string]string) error {
-	req, err := c.newRequest(ctx, http.MethodGet, rawURL, nil)
-	if err != nil {
-		return shop.Errorf(shop.ErrInternal, "build request: %v", err)
-	}
-	c.setTVSSHeaders(req)
+	requestHeaders := c.headers()
 	for _, h := range headers {
 		for k, v := range h {
-			req.Header.Set(k, v)
+			requestHeaders.Set(k, v)
 		}
 	}
 
-	return c.execute(req, dest)
+	return c.execute(ctx, http.MethodGet, rawURL, nil, requestHeaders, dest)
 }
 
 // doMutate performs an authenticated request with a JSON body for the given
@@ -141,14 +249,10 @@ func (c *tvssClient) doMutate(ctx context.Context, method, rawURL, mediaType str
 		return shop.Errorf(shop.ErrInternal, "marshal request body: %v", err)
 	}
 
-	req, err := c.newRequest(ctx, method, rawURL, bytes.NewReader(data))
-	if err != nil {
-		return shop.Errorf(shop.ErrInternal, "build request: %v", err)
-	}
-	c.setTVSSHeaders(req)
+	requestHeaders := c.headers()
 	for _, h := range headers {
 		for k, v := range h {
-			req.Header.Set(k, v)
+			requestHeaders.Set(k, v)
 		}
 	}
 
@@ -156,9 +260,9 @@ func (c *tvssClient) doMutate(ctx context.Context, method, rawURL, mediaType str
 	if mediaType != "" {
 		ct = fmt.Sprintf("application/vnd.com.amazon.tvss.api+json; type=%q", mediaType)
 	}
-	req.Header.Set("Content-Type", ct)
+	requestHeaders.Set("Content-Type", ct)
 
-	return c.execute(req, dest)
+	return c.execute(ctx, method, rawURL, bytes.NewReader(data), requestHeaders, dest)
 }
 
 // doPost performs an authenticated POST.
@@ -178,8 +282,12 @@ func (c *tvssClient) doPatch(ctx context.Context, rawURL, mediaType string, body
 
 // execute sends the request, reads the response, maps HTTP errors to
 // *shop.Error, and unmarshals the body into dest.
-func (c *tvssClient) execute(req *http.Request, dest any) error {
-	resp, err := c.http.Do(req)
+func (c *tvssClient) execute(ctx context.Context, method, rawURL string, requestBody io.Reader, headers http.Header, dest any) error {
+	resp, err := c.http.do(ctx, method, rawURL, requestBody, requestOptions{
+		profile: profileTVSS,
+		cookies: c.cookies,
+		headers: headers,
+	})
 	if err != nil {
 		return shop.Errorf(shop.ErrNetwork, "tvss request: %v", err)
 	}

--- a/internal/provider/amazon/client.go
+++ b/internal/provider/amazon/client.go
@@ -2,7 +2,6 @@ package amazon
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -16,49 +15,6 @@ import (
 
 	"github.com/saucesteals/shop"
 )
-
-// decodingTransport keeps compression behavior consistent across Amazon's
-// web and API endpoints. Amazon may return gzip without negotiating it, so
-// the underlying transport omits Accept-Encoding and responses are decoded
-// here instead of relying on net/http's conditional automatic behavior.
-type decodingTransport struct {
-	base http.RoundTripper
-}
-
-func (t *decodingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	resp, err := t.base.RoundTrip(req)
-	if err != nil || !strings.EqualFold(strings.TrimSpace(resp.Header.Get("Content-Encoding")), "gzip") {
-		return resp, err
-	}
-
-	compressed := resp.Body
-	decoded, err := gzip.NewReader(compressed)
-	if err != nil {
-		_ = compressed.Close()
-		return nil, fmt.Errorf("decode gzip response: %w", err)
-	}
-	resp.Body = &gzipReadCloser{Reader: decoded, compressed: compressed}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-
-	return resp, nil
-}
-
-type gzipReadCloser struct {
-	*gzip.Reader
-	compressed io.Closer
-}
-
-func (r *gzipReadCloser) Close() error {
-	decodeErr := r.Reader.Close()
-	compressedErr := r.compressed.Close()
-	if decodeErr != nil {
-		return decodeErr
-	}
-	return compressedErr
-}
 
 // asinPattern validates that a product ID is a well-formed 10-character
 // Amazon Standard Identification Number.

--- a/internal/provider/amazon/client.go
+++ b/internal/provider/amazon/client.go
@@ -2,6 +2,7 @@ package amazon
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -15,6 +16,49 @@ import (
 
 	"github.com/saucesteals/shop"
 )
+
+// decodingTransport keeps compression behavior consistent across Amazon's
+// web and API endpoints. Amazon may return gzip without negotiating it, so
+// the underlying transport omits Accept-Encoding and responses are decoded
+// here instead of relying on net/http's conditional automatic behavior.
+type decodingTransport struct {
+	base http.RoundTripper
+}
+
+func (t *decodingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil || !strings.EqualFold(strings.TrimSpace(resp.Header.Get("Content-Encoding")), "gzip") {
+		return resp, err
+	}
+
+	compressed := resp.Body
+	decoded, err := gzip.NewReader(compressed)
+	if err != nil {
+		_ = compressed.Close()
+		return nil, fmt.Errorf("decode gzip response: %w", err)
+	}
+	resp.Body = &gzipReadCloser{Reader: decoded, compressed: compressed}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+
+	return resp, nil
+}
+
+type gzipReadCloser struct {
+	*gzip.Reader
+	compressed io.Closer
+}
+
+func (r *gzipReadCloser) Close() error {
+	decodeErr := r.Reader.Close()
+	compressedErr := r.compressed.Close()
+	if decodeErr != nil {
+		return decodeErr
+	}
+	return compressedErr
+}
 
 // asinPattern validates that a product ID is a well-formed 10-character
 // Amazon Standard Identification Number.

--- a/internal/provider/amazon/device.go
+++ b/internal/provider/amazon/device.go
@@ -35,14 +35,14 @@ const (
 
 // Device registration constants — iOS (Amazon Shopping app).
 const (
-	defaultDeviceType    = "A3NWHXTQ4EBCZS"
-	defaultDeviceDomain  = "Device"
-	defaultAppName       = "Amazon Shopping"
-	defaultAppVersion    = "24.20.2"
-	defaultDeviceModel   = "iPhone"
-	defaultOSVersion     = "17.6.1"
-	defaultSoftwareVer   = "1"
-	serialBytes          = 12
+	defaultDeviceType   = "A3NWHXTQ4EBCZS"
+	defaultDeviceDomain = "Device"
+	defaultAppName      = "Amazon Shopping"
+	defaultAppVersion   = "24.20.2"
+	defaultDeviceModel  = "iPhone"
+	defaultOSVersion    = "17.6.1"
+	defaultSoftwareVer  = "1"
+	serialBytes         = 12
 )
 
 // HTTP constants.
@@ -105,7 +105,7 @@ type registerPayload struct {
 // registerAuthData carries the authentication method and code pair for
 // device registration.
 type registerAuthData struct {
-	UseGlobalAuthentication string          `json:"use_global_authentication"`
+	UseGlobalAuthentication string           `json:"use_global_authentication"`
 	CodePair                registerCodePair `json:"code_pair"`
 }
 
@@ -212,19 +212,16 @@ func generateDevice() (device, error) {
 // generateCodePair creates a code pair for the given device by calling the
 // Amazon auth code pair endpoint. Validates that the response contains all
 // required fields before returning.
-func generateCodePair(ctx context.Context, client *http.Client, d device) (*codePairResponse, error) {
+func generateCodePair(ctx context.Context, client *amazonClient, d device) (*codePairResponse, error) {
 	body, err := json.Marshal(codePairRequest{CodeData: d})
 	if err != nil {
 		return nil, shop.Errorf(shop.ErrInternal, "marshal code pair request: %v", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, codePairURL, bytes.NewReader(body))
-	if err != nil {
-		return nil, shop.Errorf(shop.ErrInternal, "build code pair request: %v", err)
-	}
-	setAuthHeaders(req)
-
-	resp, err := client.Do(req)
+	resp, err := client.do(ctx, http.MethodPost, codePairURL, bytes.NewReader(body), requestOptions{
+		profile: profileJSON,
+		headers: authHeaders(),
+	})
 	if err != nil {
 		return nil, shop.Errorf(shop.ErrNetwork, "code pair request: %v", err)
 	}
@@ -257,7 +254,7 @@ func generateCodePair(ctx context.Context, client *http.Client, d device) (*code
 // the code. Returns nil, nil if the user has not yet completed auth (the
 // authorization_pending case). Returns a *shop.Error for actual failures
 // (rate limits, server errors, malformed requests).
-func registerDevice(ctx context.Context, client *http.Client, d device, publicCode, privateCode string) (*registrationResult, error) {
+func registerDevice(ctx context.Context, client *amazonClient, d device, publicCode, privateCode string) (*registrationResult, error) {
 	payload := buildRegisterPayload(d, publicCode, privateCode)
 
 	body, err := json.Marshal(payload)
@@ -265,13 +262,10 @@ func registerDevice(ctx context.Context, client *http.Client, d device, publicCo
 		return nil, shop.Errorf(shop.ErrInternal, "marshal register request: %v", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, registerURL, bytes.NewReader(body))
-	if err != nil {
-		return nil, shop.Errorf(shop.ErrInternal, "build register request: %v", err)
-	}
-	setAuthHeaders(req)
-
-	resp, err := client.Do(req)
+	resp, err := client.do(ctx, http.MethodPost, registerURL, bytes.NewReader(body), requestOptions{
+		profile: profileJSON,
+		headers: authHeaders(),
+	})
 	if err != nil {
 		return nil, shop.Errorf(shop.ErrNetwork, "register request: %v", err)
 	}
@@ -375,11 +369,14 @@ func buildRegisterPayload(d device, publicCode, privateCode string) registerPayl
 	}
 }
 
-// setAuthHeaders applies the standard Amazon auth headers to a request.
-func setAuthHeaders(req *http.Request) {
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", mobileUA)
-	req.Header.Set("x-amzn-identity-auth-domain", authDomain)
+// authHeaders returns the canonical Amazon device-auth headers.
+func authHeaders() http.Header {
+	headers := make(http.Header)
+	headers.Set("Content-Type", "application/json")
+	headers.Set("User-Agent", mobileUA)
+	headers.Set("x-amzn-identity-auth-domain", authDomain)
+
+	return headers
 }
 
 // truncateBody caps the response body length for inclusion in error messages

--- a/internal/provider/amazon/offers.go
+++ b/internal/provider/amazon/offers.go
@@ -1,0 +1,316 @@
+package amazon
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/saucesteals/shop"
+	"golang.org/x/net/html"
+)
+
+const aodPageSize = 10
+
+// Offers returns every offer on the requested Amazon All Offers Display page.
+func (s *Store) Offers(ctx context.Context, productID string, query *shop.OffersQuery) (*shop.OffersResult, error) {
+	if err := validateASIN(productID); err != nil {
+		return nil, err
+	}
+
+	api, err := s.tvssAPI()
+	if err != nil {
+		return nil, err
+	}
+
+	page := 1
+	if query != nil && query.Page > 1 {
+		page = query.Page
+	}
+
+	params := url.Values{
+		"asin": {productID},
+	}
+	if page > 1 {
+		params.Set("isonlyrenderofferlist", "true")
+		params.Set("pageno", fmt.Sprintf("%d", page))
+	}
+
+	rawURL := fmt.Sprintf("https://www.%s/gp/product/ajax/aodAjaxMain?%s", s.handle, params.Encode())
+	body, err := fetchAODPage(ctx, api, rawURL, true)
+	if err != nil {
+		return nil, err
+	}
+	offers, offerCount, authenticatedParseErr := parseAODOffers(body, s.currency, api.marketplaceID)
+
+	// Amazon Business sessions can collapse AOD to the account-selected offer.
+	// Merge the anonymous catalog view so alternate sellers remain visible while
+	// preserving any account-specific offer and price returned above.
+	publicBody, err := fetchAODPage(ctx, api, rawURL, false)
+	if err != nil && authenticatedParseErr != nil {
+		return nil, authenticatedParseErr
+	}
+	if err == nil {
+		publicOffers, publicCount, publicParseErr := parseAODOffers(publicBody, s.currency, api.marketplaceID)
+		if publicParseErr != nil && authenticatedParseErr != nil {
+			return nil, authenticatedParseErr
+		}
+		if publicParseErr == nil {
+			for i := range publicOffers {
+				publicOffers[i].IsBuyBox = false
+			}
+			offers = mergeAODOffers(offers, publicOffers)
+			offerCount = max(offerCount, publicCount)
+		}
+	}
+	if query != nil && query.Condition != shop.ConditionAny {
+		offers = filterOffersByCondition(offers, query.Condition)
+	}
+
+	hasMore := offerCount >= aodPageSize
+	if query != nil && query.PageSize > 0 && len(offers) > query.PageSize {
+		offers = offers[:query.PageSize]
+		hasMore = true
+	}
+
+	return &shop.OffersResult{
+		Offers:  offers,
+		Page:    page,
+		HasMore: hasMore,
+	}, nil
+}
+
+func fetchAODPage(ctx context.Context, api *tvssClient, rawURL string, authenticated bool) ([]byte, error) {
+	var (
+		req *http.Request
+		err error
+	)
+	if authenticated {
+		req, err = api.newRequest(ctx, http.MethodGet, rawURL, nil)
+	} else {
+		req, err = http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	}
+	if err != nil {
+		return nil, shop.Errorf(shop.ErrInternal, "build Amazon offers request: %v", err)
+	}
+	req.Header.Set("User-Agent", mobileUA)
+	req.Header.Set("Accept", "text/html")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+
+	client := api.http
+	if !authenticated {
+		clone := *api.http
+		clone.Jar = nil
+		client = &clone
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, shop.Errorf(shop.ErrNetwork, "Amazon offers request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, shop.Errorf(shop.ErrNetwork, "read Amazon offers response: %v", err)
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, shop.Errorf(shop.ErrAuthExpired, "Amazon offers auth expired (%d)", resp.StatusCode)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, shop.Errorf(shop.ErrNotFound, "Amazon offers not found")
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, shop.Errorf(shop.ErrRateLimited, "Amazon offers rate limited")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, shop.Errorf(shop.ErrStoreError, "Amazon offers returned %d: %s", resp.StatusCode, truncateBody(body))
+	}
+
+	return body, nil
+}
+
+func parseAODOffers(body []byte, currency, marketplaceID string) ([]shop.Offer, int, error) {
+	doc, err := html.Parse(bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, shop.Errorf(shop.ErrStoreError, "parse Amazon offers")
+	}
+
+	pinned := reviewFind(doc, "id", "aod-pinned-offer")
+	other := reviewFind(doc, "class", "aod-other-offer-block")
+	if len(pinned) == 0 && len(other) == 0 {
+		return nil, 0, shop.Errorf(shop.ErrStoreError, "Amazon returned unrecognized offers content")
+	}
+
+	offers := make([]shop.Offer, 0, len(pinned)+len(other))
+	for _, node := range pinned {
+		offer, err := parseAODOffer(node, currency, marketplaceID)
+		if err != nil {
+			return nil, 0, err
+		}
+		offer.IsBuyBox = true
+		offers = append(offers, offer)
+	}
+	for _, node := range other {
+		offer, err := parseAODOffer(node, currency, marketplaceID)
+		if err != nil {
+			return nil, 0, err
+		}
+		offers = append(offers, offer)
+	}
+
+	return offers, len(other), nil
+}
+
+func parseAODOffer(node *html.Node, currency, marketplaceID string) (shop.Offer, error) {
+	priceText := reviewText(node)
+	price := parsePriceCents(priceText, currency)
+	if price == 0 {
+		return shop.Offer{}, shop.Errorf(shop.ErrStoreError, "Amazon offer is missing a valid price")
+	}
+
+	sellerNode := firstNode(node, "id", "aod-offer-soldBy")
+	if sellerNode == nil {
+		return shop.Offer{}, shop.Errorf(shop.ErrStoreError, "Amazon offer is missing seller information")
+	}
+	sellerName := sellerNameFromNode(sellerNode)
+	sellerID := sellerIDFromNode(sellerNode)
+	if isAmazonSeller(sellerName) {
+		sellerName = "Amazon"
+		if sellerID == "" {
+			sellerID = marketplaceID
+		}
+	}
+
+	offer := shop.Offer{
+		ID:        offerIDFromNode(node),
+		Seller:    shop.Seller{ID: sellerID, Name: sellerName},
+		Condition: parseAODCondition(reviewFirstText(node, "id", "aod-offer-heading")),
+		Price: shop.Money{
+			Amount:   price,
+			Currency: currency,
+		},
+		Availability: shop.Availability{Status: shop.AvailabilityInStock},
+		IsPrime:      len(reviewFind(node, "class", "a-icon-prime")) > 0,
+		DeliveryDate: reviewFirstText(node, "class", "aod-delivery-promise"),
+	}
+
+	if shipsFrom := firstNode(node, "id", "aod-offer-shipsFrom"); shipsFrom != nil {
+		offer.Shipping = &shop.ShippingInfo{
+			From: stripAODLabel(reviewText(shipsFrom), "Ships from"),
+		}
+	}
+
+	return offer, nil
+}
+
+func sellerNameFromNode(node *html.Node) string {
+	for _, anchor := range reviewElements(node, "a") {
+		if sellerIDFromNode(anchor) != "" {
+			return reviewText(anchor)
+		}
+	}
+
+	name := stripAODLabel(reviewText(node), "Sold by")
+	if line, _, ok := strings.Cut(name, "\n"); ok {
+		return strings.TrimSpace(line)
+	}
+
+	return name
+}
+
+func firstNode(node *html.Node, key, value string) *html.Node {
+	nodes := reviewFind(node, key, value)
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	return nodes[0]
+}
+
+func stripAODLabel(value, label string) string {
+	value = strings.TrimSpace(value)
+	if len(value) >= len(label) && strings.EqualFold(value[:len(label)], label) {
+		value = value[len(label):]
+	}
+
+	return strings.TrimSpace(strings.TrimPrefix(value, ":"))
+}
+
+func sellerIDFromNode(node *html.Node) string {
+	for _, anchor := range reviewElements(node, "a") {
+		href := reviewAttr(anchor, "href")
+		u, err := url.Parse(href)
+		if err == nil && u.Query().Get("seller") != "" {
+			return u.Query().Get("seller")
+		}
+	}
+
+	return ""
+}
+
+func offerIDFromNode(node *html.Node) string {
+	for _, input := range reviewElements(node, "input") {
+		if strings.HasSuffix(reviewAttr(input, "name"), "[offerListingId]") {
+			return reviewAttr(input, "value")
+		}
+	}
+
+	return ""
+}
+
+func isAmazonSeller(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+
+	return name == "amazon" || strings.HasPrefix(name, "amazon.")
+}
+
+func parseAODCondition(value string) shop.OfferCondition {
+	value = strings.ToLower(strings.Join(strings.Fields(value), " "))
+	switch {
+	case strings.Contains(value, "used - like new"):
+		return shop.ConditionUsedLikeNew
+	case strings.Contains(value, "used - good"):
+		return shop.ConditionUsedGood
+	case strings.Contains(value, "used - acceptable"), strings.Contains(value, "used - fair"):
+		return shop.ConditionUsedFair
+	case strings.Contains(value, "renewed"), strings.Contains(value, "refurbished"):
+		return shop.ConditionRefurbished
+	default:
+		return shop.ConditionNew
+	}
+}
+
+func filterOffersByCondition(offers []shop.Offer, condition shop.OfferCondition) []shop.Offer {
+	filtered := make([]shop.Offer, 0, len(offers))
+	for _, offer := range offers {
+		if offer.Condition == condition {
+			filtered = append(filtered, offer)
+		}
+	}
+
+	return filtered
+}
+
+func mergeAODOffers(primary, additional []shop.Offer) []shop.Offer {
+	seen := make(map[string]bool, len(primary)+len(additional))
+	merged := make([]shop.Offer, 0, len(primary)+len(additional))
+	appendUnique := func(offer shop.Offer) {
+		key := fmt.Sprintf("%s\x00%s\x00%d\x00%s", offer.Seller.ID, offer.Seller.Name, offer.Price.Amount, offer.Condition)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		merged = append(merged, offer)
+	}
+	for _, offer := range primary {
+		appendUnique(offer)
+	}
+	for _, offer := range additional {
+		appendUnique(offer)
+	}
+
+	return merged
+}

--- a/internal/provider/amazon/offers.go
+++ b/internal/provider/amazon/offers.go
@@ -2,6 +2,7 @@ package amazon
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -113,13 +114,27 @@ func (s *Store) fetchAODPage(ctx context.Context, rawURL string) ([]byte, error)
 	req.Header.Set("Accept", "text/html")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
 
-	resp, err := s.client.Do(req)
+	resp, err := s.aodClient.Do(req)
 	if err != nil {
 		return nil, shop.Errorf(shop.ErrNetwork, "Amazon offers request: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, aodMaxBodyBytes+1))
+	reader := io.Reader(resp.Body)
+	switch strings.ToLower(strings.TrimSpace(resp.Header.Get("Content-Encoding"))) {
+	case "", "identity":
+	case "gzip":
+		compressed, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return nil, shop.Errorf(shop.ErrStoreError, "decode Amazon offers response: %v", err)
+		}
+		defer func() { _ = compressed.Close() }()
+		reader = compressed
+	default:
+		return nil, shop.Errorf(shop.ErrStoreError, "Amazon offers returned unsupported content encoding")
+	}
+
+	body, err := io.ReadAll(io.LimitReader(reader, aodMaxBodyBytes+1))
 	if err != nil {
 		return nil, shop.Errorf(shop.ErrNetwork, "read Amazon offers response: %v", err)
 	}

--- a/internal/provider/amazon/offers.go
+++ b/internal/provider/amazon/offers.go
@@ -92,34 +92,35 @@ func (s *Store) fetchAODOffers(ctx context.Context, api *tvssClient, productID s
 	}
 	rawURL := fmt.Sprintf("https://www.%s/gp/product/ajax/aodAjaxMain?%s", s.handle, params.Encode())
 
-	body, err := fetchAODPage(ctx, api, rawURL, true)
+	// The anonymous response is the authoritative seller catalog. Never return
+	// an authenticated buy-box-only response as though it were complete.
+	publicBody, err := fetchAODPage(ctx, api, rawURL, false)
 	if err != nil {
 		return nil, false, err
 	}
-	offers, authenticatedCount, authenticatedParseErr := parseAODOffers(body, s.currency, api.marketplaceID)
+	publicOffers, publicCount, err := parseAODOffers(publicBody, s.currency, api.marketplaceID)
+	if err != nil {
+		return nil, false, err
+	}
 
 	// Amazon Business sessions can collapse AOD to the account-selected offer.
-	// Merge the anonymous catalog view so alternate sellers remain visible while
-	// preserving any account-specific offer and price returned above.
-	publicBody, publicFetchErr := fetchAODPage(ctx, api, rawURL, false)
-	if publicFetchErr != nil {
-		if authenticatedParseErr != nil {
-			return nil, false, authenticatedParseErr
-		}
-		return offers, authenticatedCount < aodPageSize, nil
+	// Merge it when available, but a transient authenticated-page failure must
+	// not hide the complete public catalog.
+	authenticatedBody, authenticatedFetchErr := fetchAODPage(ctx, api, rawURL, true)
+	if authenticatedFetchErr != nil {
+		return publicOffers, publicCount < aodPageSize, nil
 	}
-	publicOffers, publicCount, publicParseErr := parseAODOffers(publicBody, s.currency, api.marketplaceID)
-	if publicParseErr != nil {
-		if authenticatedParseErr != nil {
-			return nil, false, authenticatedParseErr
-		}
-		return offers, authenticatedCount < aodPageSize, nil
+	authenticatedOffers, _, authenticatedParseErr := parseAODOffers(authenticatedBody, s.currency, api.marketplaceID)
+	if authenticatedParseErr != nil {
+		return publicOffers, publicCount < aodPageSize, nil
 	}
-	for i := range publicOffers {
-		publicOffers[i].IsBuyBox = false
+	if len(authenticatedOffers) > 0 {
+		for i := range publicOffers {
+			publicOffers[i].IsBuyBox = false
+		}
 	}
 
-	return mergeAODOffers(offers, publicOffers), publicCount < aodPageSize, nil
+	return mergeAODOffers(authenticatedOffers, publicOffers), publicCount < aodPageSize, nil
 }
 
 func fetchAODPage(ctx context.Context, api *tvssClient, rawURL string, authenticated bool) ([]byte, error) {

--- a/internal/provider/amazon/offers.go
+++ b/internal/provider/amazon/offers.go
@@ -3,6 +3,7 @@ package amazon
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -192,9 +193,13 @@ func parseAODOffer(node *html.Node, currency, marketplaceID string) (shop.Offer,
 			sellerID = marketplaceID
 		}
 	}
+	offerID := offerIDFromNode(node)
+	if offerID == "" {
+		return shop.Offer{}, shop.Errorf(shop.ErrStoreError, "Amazon offer is missing its offer ID")
+	}
 
 	offer := shop.Offer{
-		ID:        offerIDFromNode(node),
+		ID:        offerID,
 		Seller:    shop.Seller{ID: sellerID, Name: sellerName},
 		Condition: parseAODCondition(reviewFirstText(node, "id", "aod-offer-heading")),
 		Price: shop.Money{
@@ -261,18 +266,56 @@ func sellerIDFromNode(node *html.Node) string {
 }
 
 func offerIDFromNode(node *html.Node) string {
+	// Amazon's mobile AOD embeds the offer token as `oid` in a JSON action
+	// payload. The HTML parser has already decoded attribute entities here.
+	var offerID string
+	var walk func(*html.Node)
+	walk = func(current *html.Node) {
+		if offerID != "" {
+			return
+		}
+		if current.Type == html.ElementNode {
+			for _, attribute := range []string{"data-aw-aod-cart-api", "data-select-aod-qty-atc"} {
+				raw := reviewAttr(current, attribute)
+				if raw == "" {
+					continue
+				}
+				var action struct {
+					OfferID string `json:"oid"`
+				}
+				if err := json.Unmarshal([]byte(raw), &action); err == nil && action.OfferID != "" {
+					offerID = decodeAODOfferID(action.OfferID)
+					return
+				}
+			}
+		}
+		for child := current.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(node)
+	if offerID != "" {
+		return offerID
+	}
+
+	// Retain compatibility with desktop AOD variants that expose the token as
+	// a conventional hidden form field.
 	for _, input := range reviewElements(node, "input") {
 		if strings.HasSuffix(reviewAttr(input, "name"), "[offerListingId]") {
-			raw := reviewAttr(input, "value")
-			offerID, err := url.PathUnescape(raw)
-			if err != nil {
-				return raw
-			}
-			return offerID
+			return decodeAODOfferID(reviewAttr(input, "value"))
 		}
 	}
 
 	return ""
+}
+
+func decodeAODOfferID(raw string) string {
+	offerID, err := url.PathUnescape(raw)
+	if err != nil {
+		return raw
+	}
+
+	return offerID
 }
 
 func isAmazonSeller(name string) bool {

--- a/internal/provider/amazon/offers.go
+++ b/internal/provider/amazon/offers.go
@@ -2,7 +2,6 @@ package amazon
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -114,27 +113,13 @@ func (s *Store) fetchAODPage(ctx context.Context, rawURL string) ([]byte, error)
 	req.Header.Set("Accept", "text/html")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
 
-	resp, err := s.offersClient.Do(req)
+	resp, err := s.client.Do(req)
 	if err != nil {
 		return nil, shop.Errorf(shop.ErrNetwork, "Amazon offers request: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	reader := io.Reader(resp.Body)
-	switch strings.ToLower(strings.TrimSpace(resp.Header.Get("Content-Encoding"))) {
-	case "", "identity":
-	case "gzip":
-		compressed, err := gzip.NewReader(resp.Body)
-		if err != nil {
-			return nil, shop.Errorf(shop.ErrStoreError, "decode Amazon offers response: %v", err)
-		}
-		defer func() { _ = compressed.Close() }()
-		reader = compressed
-	default:
-		return nil, shop.Errorf(shop.ErrStoreError, "Amazon offers returned unsupported content encoding")
-	}
-
-	body, err := io.ReadAll(io.LimitReader(reader, aodMaxBodyBytes+1))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, aodMaxBodyBytes+1))
 	if err != nil {
 		return nil, shop.Errorf(shop.ErrNetwork, "read Amazon offers response: %v", err)
 	}

--- a/internal/provider/amazon/offers.go
+++ b/internal/provider/amazon/offers.go
@@ -2,6 +2,7 @@ package amazon
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -113,13 +114,27 @@ func (s *Store) fetchAODPage(ctx context.Context, rawURL string) ([]byte, error)
 	req.Header.Set("Accept", "text/html")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
 
-	resp, err := s.client.Do(req)
+	resp, err := s.offersClient.Do(req)
 	if err != nil {
 		return nil, shop.Errorf(shop.ErrNetwork, "Amazon offers request: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, aodMaxBodyBytes+1))
+	reader := io.Reader(resp.Body)
+	switch strings.ToLower(strings.TrimSpace(resp.Header.Get("Content-Encoding"))) {
+	case "", "identity":
+	case "gzip":
+		compressed, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return nil, shop.Errorf(shop.ErrStoreError, "decode Amazon offers response: %v", err)
+		}
+		defer func() { _ = compressed.Close() }()
+		reader = compressed
+	default:
+		return nil, shop.Errorf(shop.ErrStoreError, "Amazon offers returned unsupported content encoding")
+	}
+
+	body, err := io.ReadAll(io.LimitReader(reader, aodMaxBodyBytes+1))
 	if err != nil {
 		return nil, shop.Errorf(shop.ErrNetwork, "read Amazon offers response: %v", err)
 	}

--- a/internal/provider/amazon/offers.go
+++ b/internal/provider/amazon/offers.go
@@ -37,11 +37,6 @@ func (s *Store) Offers(ctx context.Context, productID string, query *shop.Offers
 		return nil, shop.Errorf(shop.ErrInvalidInput, "Amazon offers support pages 1–100")
 	}
 
-	api, err := s.tvssAPI()
-	if err != nil {
-		return nil, err
-	}
-
 	// Amazon serves fixed ten-offer batches. Replay them to expose stable logical
 	// pages for arbitrary caller page sizes without skipping offers.
 	start, end := (q.Page-1)*q.PageSize, q.Page*q.PageSize
@@ -52,7 +47,7 @@ func (s *Store) Offers(ctx context.Context, productID string, query *shop.Offers
 	seen := make(map[string]bool)
 	position := 0
 	for amazonPage := 1; position <= end; amazonPage++ {
-		offers, exhausted, err := s.fetchAODOffers(ctx, api, productID, amazonPage)
+		offers, exhausted, err := s.fetchAODOffers(ctx, productID, amazonPage)
 		if err != nil {
 			return nil, err
 		}
@@ -82,7 +77,7 @@ func (s *Store) Offers(ctx context.Context, productID string, query *shop.Offers
 	return result, nil
 }
 
-func (s *Store) fetchAODOffers(ctx context.Context, api *tvssClient, productID string, page int) ([]shop.Offer, bool, error) {
+func (s *Store) fetchAODOffers(ctx context.Context, productID string, page int) ([]shop.Offer, bool, error) {
 	params := url.Values{
 		"asin": {productID},
 	}
@@ -92,47 +87,20 @@ func (s *Store) fetchAODOffers(ctx context.Context, api *tvssClient, productID s
 	}
 	rawURL := fmt.Sprintf("https://www.%s/gp/product/ajax/aodAjaxMain?%s", s.handle, params.Encode())
 
-	// The anonymous response is the authoritative seller catalog. Never return
-	// an authenticated buy-box-only response as though it were complete.
-	publicBody, err := fetchAODPage(ctx, api, rawURL, false)
+	body, err := s.fetchAODPage(ctx, rawURL)
 	if err != nil {
 		return nil, false, err
 	}
-	publicOffers, publicCount, err := parseAODOffers(publicBody, s.currency, api.marketplaceID)
+	offers, count, err := parseAODOffers(body, s.currency, s.marketplaceID)
 	if err != nil {
 		return nil, false, err
 	}
 
-	// Amazon Business sessions can collapse AOD to the account-selected offer.
-	// Merge it when available, but a transient authenticated-page failure must
-	// not hide the complete public catalog.
-	authenticatedBody, authenticatedFetchErr := fetchAODPage(ctx, api, rawURL, true)
-	if authenticatedFetchErr != nil {
-		return publicOffers, publicCount < aodPageSize, nil
-	}
-	authenticatedOffers, _, authenticatedParseErr := parseAODOffers(authenticatedBody, s.currency, api.marketplaceID)
-	if authenticatedParseErr != nil {
-		return publicOffers, publicCount < aodPageSize, nil
-	}
-	if len(authenticatedOffers) > 0 {
-		for i := range publicOffers {
-			publicOffers[i].IsBuyBox = false
-		}
-	}
-
-	return mergeAODOffers(authenticatedOffers, publicOffers), publicCount < aodPageSize, nil
+	return offers, count < aodPageSize, nil
 }
 
-func fetchAODPage(ctx context.Context, api *tvssClient, rawURL string, authenticated bool) ([]byte, error) {
-	var (
-		req *http.Request
-		err error
-	)
-	if authenticated {
-		req, err = api.newRequest(ctx, http.MethodGet, rawURL, nil)
-	} else {
-		req, err = http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
-	}
+func (s *Store) fetchAODPage(ctx context.Context, rawURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return nil, shop.Errorf(shop.ErrInternal, "build Amazon offers request: %v", err)
 	}
@@ -140,13 +108,7 @@ func fetchAODPage(ctx context.Context, api *tvssClient, rawURL string, authentic
 	req.Header.Set("Accept", "text/html")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
 
-	client := api.http
-	if !authenticated {
-		clone := *api.http
-		clone.Jar = nil
-		client = &clone
-	}
-	resp, err := client.Do(req)
+	resp, err := s.client.Do(req)
 	if err != nil {
 		return nil, shop.Errorf(shop.ErrNetwork, "Amazon offers request: %v", err)
 	}
@@ -326,27 +288,6 @@ func parseAODCondition(value string) shop.OfferCondition {
 	default:
 		return shop.ConditionNew
 	}
-}
-
-func mergeAODOffers(primary, additional []shop.Offer) []shop.Offer {
-	seen := make(map[string]bool, len(primary)+len(additional))
-	merged := make([]shop.Offer, 0, len(primary)+len(additional))
-	appendUnique := func(offer shop.Offer) {
-		key := aodOfferKey(offer)
-		if seen[key] {
-			return
-		}
-		seen[key] = true
-		merged = append(merged, offer)
-	}
-	for _, offer := range primary {
-		appendUnique(offer)
-	}
-	for _, offer := range additional {
-		appendUnique(offer)
-	}
-
-	return merged
 }
 
 func aodOfferKey(offer shop.Offer) string {

--- a/internal/provider/amazon/offers.go
+++ b/internal/provider/amazon/offers.go
@@ -13,7 +13,11 @@ import (
 	"golang.org/x/net/html"
 )
 
-const aodPageSize = 10
+const (
+	aodPageSize     = 10
+	aodMaxPages     = 100
+	aodMaxBodyBytes = 8 << 20
+)
 
 // Offers returns every offer on the requested Amazon All Offers Display page.
 func (s *Store) Offers(ctx context.Context, productID string, query *shop.OffersQuery) (*shop.OffersResult, error) {
@@ -33,12 +37,12 @@ func (s *Store) Offers(ctx context.Context, productID string, query *shop.Offers
 	if q.PageSize == 0 {
 		q.PageSize = aodPageSize
 	}
-	if q.Page > 100 {
-		return nil, shop.Errorf(shop.ErrInvalidInput, "Amazon offers support pages 1–100")
-	}
-
 	// Amazon serves fixed ten-offer batches. Replay them to expose stable logical
 	// pages for arbitrary caller page sizes without skipping offers.
+	maxLogicalPage := (aodPageSize*aodMaxPages + q.PageSize - 1) / q.PageSize
+	if q.Page > maxLogicalPage {
+		return nil, shop.Errorf(shop.ErrInvalidInput, "Amazon offers support offsets below %d", aodPageSize*aodMaxPages)
+	}
 	start, end := (q.Page-1)*q.PageSize, q.Page*q.PageSize
 	result := &shop.OffersResult{
 		Offers: []shop.Offer{},
@@ -46,7 +50,7 @@ func (s *Store) Offers(ctx context.Context, productID string, query *shop.Offers
 	}
 	seen := make(map[string]bool)
 	position := 0
-	for amazonPage := 1; position <= end; amazonPage++ {
+	for amazonPage := 1; position <= end && amazonPage <= aodMaxPages; amazonPage++ {
 		offers, exhausted, err := s.fetchAODOffers(ctx, productID, amazonPage)
 		if err != nil {
 			return nil, err
@@ -114,12 +118,15 @@ func (s *Store) fetchAODPage(ctx context.Context, rawURL string) ([]byte, error)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, aodMaxBodyBytes+1))
 	if err != nil {
 		return nil, shop.Errorf(shop.ErrNetwork, "read Amazon offers response: %v", err)
 	}
+	if len(body) > aodMaxBodyBytes {
+		return nil, shop.Errorf(shop.ErrStoreError, "Amazon offers response exceeded size limit")
+	}
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return nil, shop.Errorf(shop.ErrAuthExpired, "Amazon offers auth expired (%d)", resp.StatusCode)
+		return nil, shop.Errorf(shop.ErrStoreError, "Amazon offers access denied (%d)", resp.StatusCode)
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, shop.Errorf(shop.ErrNotFound, "Amazon offers not found")

--- a/internal/provider/amazon/offers.go
+++ b/internal/provider/amazon/offers.go
@@ -2,7 +2,6 @@ package amazon
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -106,35 +105,15 @@ func (s *Store) fetchAODOffers(ctx context.Context, productID string, page int) 
 }
 
 func (s *Store) fetchAODPage(ctx context.Context, rawURL string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
-	if err != nil {
-		return nil, shop.Errorf(shop.ErrInternal, "build Amazon offers request: %v", err)
-	}
-	req.Header.Set("User-Agent", mobileUA)
-	req.Header.Set("Accept", "text/html")
-	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
-
-	resp, err := s.aodClient.Do(req)
+	resp, err := s.client.do(ctx, http.MethodGet, rawURL, nil, requestOptions{
+		profile: profileAOD,
+	})
 	if err != nil {
 		return nil, shop.Errorf(shop.ErrNetwork, "Amazon offers request: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	reader := io.Reader(resp.Body)
-	switch strings.ToLower(strings.TrimSpace(resp.Header.Get("Content-Encoding"))) {
-	case "", "identity":
-	case "gzip":
-		compressed, err := gzip.NewReader(resp.Body)
-		if err != nil {
-			return nil, shop.Errorf(shop.ErrStoreError, "decode Amazon offers response: %v", err)
-		}
-		defer func() { _ = compressed.Close() }()
-		reader = compressed
-	default:
-		return nil, shop.Errorf(shop.ErrStoreError, "Amazon offers returned unsupported content encoding")
-	}
-
-	body, err := io.ReadAll(io.LimitReader(reader, aodMaxBodyBytes+1))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, aodMaxBodyBytes+1))
 	if err != nil {
 		return nil, shop.Errorf(shop.ErrNetwork, "read Amazon offers response: %v", err)
 	}

--- a/internal/provider/amazon/offers.go
+++ b/internal/provider/amazon/offers.go
@@ -20,17 +20,69 @@ func (s *Store) Offers(ctx context.Context, productID string, query *shop.Offers
 	if err := validateASIN(productID); err != nil {
 		return nil, err
 	}
+	q := shop.OffersQuery{}
+	if query != nil {
+		q = *query
+	}
+	if q.Page < 0 || q.PageSize < 0 || q.PageSize > 100 {
+		return nil, shop.Errorf(shop.ErrInvalidInput, "page must be positive and page-size must be between 1 and 100")
+	}
+	if q.Page == 0 {
+		q.Page = 1
+	}
+	if q.PageSize == 0 {
+		q.PageSize = aodPageSize
+	}
+	if q.Page > 100 {
+		return nil, shop.Errorf(shop.ErrInvalidInput, "Amazon offers support pages 1–100")
+	}
 
 	api, err := s.tvssAPI()
 	if err != nil {
 		return nil, err
 	}
 
-	page := 1
-	if query != nil && query.Page > 1 {
-		page = query.Page
+	// Amazon serves fixed ten-offer batches. Replay them to expose stable logical
+	// pages for arbitrary caller page sizes without skipping offers.
+	start, end := (q.Page-1)*q.PageSize, q.Page*q.PageSize
+	result := &shop.OffersResult{
+		Offers: []shop.Offer{},
+		Page:   q.Page,
 	}
+	seen := make(map[string]bool)
+	position := 0
+	for amazonPage := 1; position <= end; amazonPage++ {
+		offers, exhausted, err := s.fetchAODOffers(ctx, api, productID, amazonPage)
+		if err != nil {
+			return nil, err
+		}
 
+		newOffers := 0
+		for _, offer := range offers {
+			key := aodOfferKey(offer)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			newOffers++
+			if q.Condition != shop.ConditionAny && offer.Condition != q.Condition {
+				continue
+			}
+			if position >= start && position < end {
+				result.Offers = append(result.Offers, offer)
+			}
+			position++
+		}
+		if exhausted || newOffers == 0 {
+			break
+		}
+	}
+	result.HasMore = position > end
+
+	return result, nil
+}
+
+func (s *Store) fetchAODOffers(ctx context.Context, api *tvssClient, productID string, page int) ([]shop.Offer, bool, error) {
 	params := url.Values{
 		"asin": {productID},
 	}
@@ -38,49 +90,36 @@ func (s *Store) Offers(ctx context.Context, productID string, query *shop.Offers
 		params.Set("isonlyrenderofferlist", "true")
 		params.Set("pageno", fmt.Sprintf("%d", page))
 	}
-
 	rawURL := fmt.Sprintf("https://www.%s/gp/product/ajax/aodAjaxMain?%s", s.handle, params.Encode())
+
 	body, err := fetchAODPage(ctx, api, rawURL, true)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	offers, offerCount, authenticatedParseErr := parseAODOffers(body, s.currency, api.marketplaceID)
+	offers, authenticatedCount, authenticatedParseErr := parseAODOffers(body, s.currency, api.marketplaceID)
 
 	// Amazon Business sessions can collapse AOD to the account-selected offer.
 	// Merge the anonymous catalog view so alternate sellers remain visible while
 	// preserving any account-specific offer and price returned above.
-	publicBody, err := fetchAODPage(ctx, api, rawURL, false)
-	if err != nil && authenticatedParseErr != nil {
-		return nil, authenticatedParseErr
-	}
-	if err == nil {
-		publicOffers, publicCount, publicParseErr := parseAODOffers(publicBody, s.currency, api.marketplaceID)
-		if publicParseErr != nil && authenticatedParseErr != nil {
-			return nil, authenticatedParseErr
+	publicBody, publicFetchErr := fetchAODPage(ctx, api, rawURL, false)
+	if publicFetchErr != nil {
+		if authenticatedParseErr != nil {
+			return nil, false, authenticatedParseErr
 		}
-		if publicParseErr == nil {
-			for i := range publicOffers {
-				publicOffers[i].IsBuyBox = false
-			}
-			offers = mergeAODOffers(offers, publicOffers)
-			offerCount = max(offerCount, publicCount)
-		}
+		return offers, authenticatedCount < aodPageSize, nil
 	}
-	if query != nil && query.Condition != shop.ConditionAny {
-		offers = filterOffersByCondition(offers, query.Condition)
+	publicOffers, publicCount, publicParseErr := parseAODOffers(publicBody, s.currency, api.marketplaceID)
+	if publicParseErr != nil {
+		if authenticatedParseErr != nil {
+			return nil, false, authenticatedParseErr
+		}
+		return offers, authenticatedCount < aodPageSize, nil
+	}
+	for i := range publicOffers {
+		publicOffers[i].IsBuyBox = false
 	}
 
-	hasMore := offerCount >= aodPageSize
-	if query != nil && query.PageSize > 0 && len(offers) > query.PageSize {
-		offers = offers[:query.PageSize]
-		hasMore = true
-	}
-
-	return &shop.OffersResult{
-		Offers:  offers,
-		Page:    page,
-		HasMore: hasMore,
-	}, nil
+	return mergeAODOffers(offers, publicOffers), publicCount < aodPageSize, nil
 }
 
 func fetchAODPage(ctx context.Context, api *tvssClient, rawURL string, authenticated bool) ([]byte, error) {
@@ -254,7 +293,12 @@ func sellerIDFromNode(node *html.Node) string {
 func offerIDFromNode(node *html.Node) string {
 	for _, input := range reviewElements(node, "input") {
 		if strings.HasSuffix(reviewAttr(input, "name"), "[offerListingId]") {
-			return reviewAttr(input, "value")
+			raw := reviewAttr(input, "value")
+			offerID, err := url.PathUnescape(raw)
+			if err != nil {
+				return raw
+			}
+			return offerID
 		}
 	}
 
@@ -283,22 +327,11 @@ func parseAODCondition(value string) shop.OfferCondition {
 	}
 }
 
-func filterOffersByCondition(offers []shop.Offer, condition shop.OfferCondition) []shop.Offer {
-	filtered := make([]shop.Offer, 0, len(offers))
-	for _, offer := range offers {
-		if offer.Condition == condition {
-			filtered = append(filtered, offer)
-		}
-	}
-
-	return filtered
-}
-
 func mergeAODOffers(primary, additional []shop.Offer) []shop.Offer {
 	seen := make(map[string]bool, len(primary)+len(additional))
 	merged := make([]shop.Offer, 0, len(primary)+len(additional))
 	appendUnique := func(offer shop.Offer) {
-		key := fmt.Sprintf("%s\x00%s\x00%d\x00%s", offer.Seller.ID, offer.Seller.Name, offer.Price.Amount, offer.Condition)
+		key := aodOfferKey(offer)
 		if seen[key] {
 			return
 		}
@@ -313,4 +346,20 @@ func mergeAODOffers(primary, additional []shop.Offer) []shop.Offer {
 	}
 
 	return merged
+}
+
+func aodOfferKey(offer shop.Offer) string {
+	if offer.ID != "" {
+		return "id\x00" + offer.ID
+	}
+
+	shipping := ""
+	if offer.Shipping != nil {
+		shipping = fmt.Sprintf("%s\x00%s\x00%s", offer.Shipping.From, offer.Shipping.Description, offer.Shipping.Speed)
+		if offer.Shipping.Price != nil {
+			shipping += fmt.Sprintf("\x00%d\x00%s", offer.Shipping.Price.Amount, offer.Shipping.Price.Currency)
+		}
+	}
+
+	return fmt.Sprintf("fallback\x00%s\x00%s\x00%d\x00%s\x00%s\x00%s", offer.Seller.ID, offer.Seller.Name, offer.Price.Amount, offer.Price.Currency, offer.Condition, shipping)
 }

--- a/internal/provider/amazon/offers_test.go
+++ b/internal/provider/amazon/offers_test.go
@@ -169,7 +169,7 @@ func offerPage(first, last int) string {
 <div id="aod-offer-soldBy">Sold by Amazon.com</div>
 <div id="aod-offer-shipsFrom">Ships from Amazon</div>
 <span>$10.%02d</span>
-<input name="items[0.base][offerListingId]" value="offer-%d" />
+<span data-action="aw-aod-cart-api" data-aw-aod-cart-api="{&quot;oid&quot;:&quot;offer-%d&quot;}"></span>
 </div>`, i, i)
 	}
 	body.WriteString("</body></html>")

--- a/internal/provider/amazon/offers_test.go
+++ b/internal/provider/amazon/offers_test.go
@@ -1,0 +1,187 @@
+package amazon
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/saucesteals/shop"
+)
+
+type offerRoundTripper struct {
+	pages    map[string]string
+	requests []string
+}
+
+func (t *offerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	page := req.URL.Query().Get("pageno")
+	if page == "" {
+		page = "1"
+	}
+	t.requests = append(t.requests, page)
+	body, ok := t.pages[page]
+	if !ok {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("not found")),
+			Header:     make(http.Header),
+		}, nil
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestOffersLogicalPagination(t *testing.T) {
+	transport := &offerRoundTripper{
+		pages: map[string]string{
+			"1": offerPage(1, 10),
+			"2": offerPage(11, 13),
+		},
+	}
+	store := testOfferStore(transport)
+
+	result, err := store.Offers(context.Background(), "B0F2BDXW4J", &shop.OffersQuery{
+		Page:     2,
+		PageSize: 5,
+	})
+	if err != nil {
+		t.Fatalf("Offers() error = %v", err)
+	}
+	if got, want := offerIDs(result.Offers), "offer-6,offer-7,offer-8,offer-9,offer-10"; got != want {
+		t.Fatalf("offer IDs = %q, want %q", got, want)
+	}
+	if !result.HasMore {
+		t.Fatal("HasMore = false, want true")
+	}
+	if got, want := strings.Join(transport.requests, ","), "1,2"; got != want {
+		t.Fatalf("requested pages = %q, want %q", got, want)
+	}
+}
+
+func TestOffersFinalPartialPage(t *testing.T) {
+	transport := &offerRoundTripper{
+		pages: map[string]string{
+			"1": offerPage(1, 10),
+			"2": offerPage(11, 13),
+		},
+	}
+	store := testOfferStore(transport)
+
+	result, err := store.Offers(context.Background(), "B0F2BDXW4J", &shop.OffersQuery{
+		Page:     3,
+		PageSize: 5,
+	})
+	if err != nil {
+		t.Fatalf("Offers() error = %v", err)
+	}
+	if got, want := offerIDs(result.Offers), "offer-11,offer-12,offer-13"; got != want {
+		t.Fatalf("offer IDs = %q, want %q", got, want)
+	}
+	if result.HasMore {
+		t.Fatal("HasMore = true, want false")
+	}
+}
+
+func TestOffersRejectsExcessiveOffset(t *testing.T) {
+	store := testOfferStore(&offerRoundTripper{})
+
+	_, err := store.Offers(context.Background(), "B0F2BDXW4J", &shop.OffersQuery{
+		Page:     11,
+		PageSize: 100,
+	})
+	if err == nil {
+		t.Fatal("Offers() error = nil, want invalid input")
+	}
+}
+
+func TestOffersRejectsOverflowingPage(t *testing.T) {
+	store := testOfferStore(&offerRoundTripper{})
+
+	_, err := store.Offers(context.Background(), "B0F2BDXW4J", &shop.OffersQuery{
+		Page:     int(^uint(0) >> 1),
+		PageSize: 100,
+	})
+	if err == nil {
+		t.Fatal("Offers() error = nil, want invalid input")
+	}
+}
+
+func TestOffersRejectsOversizedResponse(t *testing.T) {
+	transport := &offerRoundTripper{
+		pages: map[string]string{
+			"1": strings.Repeat("x", aodMaxBodyBytes+1),
+		},
+	}
+	store := testOfferStore(transport)
+
+	_, err := store.Offers(context.Background(), "B0F2BDXW4J", nil)
+	if err == nil {
+		t.Fatal("Offers() error = nil, want response size error")
+	}
+}
+
+func TestParseAODOffer(t *testing.T) {
+	body := offerPage(1, 1)
+	offers, count, err := parseAODOffers([]byte(body), "USD", "ATVPDKIKX0DER")
+	if err != nil {
+		t.Fatalf("parseAODOffers() error = %v", err)
+	}
+	if count != 1 || len(offers) != 1 {
+		t.Fatalf("parsed count = %d, offers = %d, want 1", count, len(offers))
+	}
+	offer := offers[0]
+	if offer.ID != "offer-1" {
+		t.Fatalf("offer ID = %q, want %q", offer.ID, "offer-1")
+	}
+	if offer.Seller.Name != "Amazon" || offer.Seller.ID != "ATVPDKIKX0DER" {
+		t.Fatalf("seller = %#v, want Amazon marketplace seller", offer.Seller)
+	}
+	if offer.Shipping == nil || offer.Shipping.From != "Amazon" {
+		t.Fatalf("shipping = %#v, want Amazon", offer.Shipping)
+	}
+	if offer.Price.Amount != 1001 {
+		t.Fatalf("price = %d, want 1001", offer.Price.Amount)
+	}
+}
+
+func testOfferStore(transport http.RoundTripper) *Store {
+	return &Store{
+		handle:        "amazon.com",
+		client:        &http.Client{Transport: transport},
+		currency:      "USD",
+		marketplaceID: "ATVPDKIKX0DER",
+	}
+}
+
+func offerPage(first, last int) string {
+	var body strings.Builder
+	body.WriteString("<html><body>")
+	for i := first; i <= last; i++ {
+		fmt.Fprintf(&body, `<div class="aod-other-offer-block">
+<div id="aod-offer-heading">New</div>
+<div id="aod-offer-soldBy">Sold by Amazon.com</div>
+<div id="aod-offer-shipsFrom">Ships from Amazon</div>
+<span>$10.%02d</span>
+<input name="items[0.base][offerListingId]" value="offer-%d" />
+</div>`, i, i)
+	}
+	body.WriteString("</body></html>")
+
+	return body.String()
+}
+
+func offerIDs(offers []shop.Offer) string {
+	ids := make([]string, len(offers))
+	for i, offer := range offers {
+		ids[i] = offer.ID
+	}
+
+	return strings.Join(ids, ",")
+}

--- a/internal/provider/amazon/offers_test.go
+++ b/internal/provider/amazon/offers_test.go
@@ -153,8 +153,10 @@ func TestParseAODOffer(t *testing.T) {
 
 func testOfferStore(transport http.RoundTripper) *Store {
 	return &Store{
-		handle:        "amazon.com",
-		aodClient:     &http.Client{Transport: transport},
+		handle: "amazon.com",
+		client: &amazonClient{http: &http.Client{
+			Transport: transport,
+		}},
 		currency:      "USD",
 		marketplaceID: "ATVPDKIKX0DER",
 	}

--- a/internal/provider/amazon/offers_test.go
+++ b/internal/provider/amazon/offers_test.go
@@ -154,7 +154,7 @@ func TestParseAODOffer(t *testing.T) {
 func testOfferStore(transport http.RoundTripper) *Store {
 	return &Store{
 		handle:        "amazon.com",
-		client:        &http.Client{Transport: transport},
+		offersClient:  &http.Client{Transport: transport},
 		currency:      "USD",
 		marketplaceID: "ATVPDKIKX0DER",
 	}

--- a/internal/provider/amazon/offers_test.go
+++ b/internal/provider/amazon/offers_test.go
@@ -154,7 +154,7 @@ func TestParseAODOffer(t *testing.T) {
 func testOfferStore(transport http.RoundTripper) *Store {
 	return &Store{
 		handle:        "amazon.com",
-		client:        &http.Client{Transport: transport},
+		aodClient:     &http.Client{Transport: transport},
 		currency:      "USD",
 		marketplaceID: "ATVPDKIKX0DER",
 	}

--- a/internal/provider/amazon/offers_test.go
+++ b/internal/provider/amazon/offers_test.go
@@ -154,7 +154,7 @@ func TestParseAODOffer(t *testing.T) {
 func testOfferStore(transport http.RoundTripper) *Store {
 	return &Store{
 		handle:        "amazon.com",
-		offersClient:  &http.Client{Transport: transport},
+		client:        &http.Client{Transport: transport},
 		currency:      "USD",
 		marketplaceID: "ATVPDKIKX0DER",
 	}

--- a/internal/provider/amazon/product.go
+++ b/internal/provider/amazon/product.go
@@ -34,66 +34,6 @@ func (s *Store) Product(ctx context.Context, productID string) (*shop.Product, e
 	return mapProduct(&tp, s.handle, s.currency), nil
 }
 
-// Offers returns the buy-box offer for the product. The TVSS API does not
-// expose a multi-seller offers listing — it returns a single merchant per
-// product detail call. We return that as a single-offer result.
-//
-// TVSS endpoint: GET /marketplaces/{marketplace}/products/{asin}
-func (s *Store) Offers(ctx context.Context, productID string, _ *shop.OffersQuery) (*shop.OffersResult, error) {
-	if err := validateASIN(productID); err != nil {
-		return nil, err
-	}
-
-	api, err := s.tvssAPI()
-	if err != nil {
-		return nil, err
-	}
-
-	u := api.tvssPath([]string{"products", productID}, nil)
-
-	var tp tvssProduct
-	if err := api.doGet(ctx, u, &tp); err != nil {
-		return nil, err
-	}
-
-	result := &shop.OffersResult{
-		Page:    1,
-		HasMore: false,
-	}
-
-	offer := shop.Offer{
-		ID:        tp.OfferID,
-		Condition: shop.ConditionNew,
-		Price:     toMoney(tp.Price, s.currency),
-		Availability: shop.Availability{
-			Status: mapAvailabilityStatus(tp.ProductAvailability),
-		},
-		IsBuyBox: true,
-	}
-
-	if tp.MerchantInfo != nil {
-		offer.Seller = shop.Seller{
-			ID:   tp.MerchantInfo.MerchantID,
-			Name: tp.MerchantInfo.MerchantName,
-		}
-		offer.IsPrime = tp.MerchantInfo.SoldByAmazon
-	}
-
-	if tp.ShippingDetails != nil {
-		si := &shop.ShippingInfo{
-			Description: tp.ShippingDetails.ShippingCost,
-		}
-		if tp.ShippingDetails.FreeShipping {
-			si.Description = "Free Shipping"
-		}
-		offer.Shipping = si
-	}
-
-	result.Offers = append(result.Offers, offer)
-
-	return result, nil
-}
-
 // Variants returns the variation tree for a product.
 //
 // TVSS endpoint: GET /marketplaces/{marketplace}/products/{asin}/variations

--- a/internal/provider/amazon/reviews.go
+++ b/internal/provider/amazon/reviews.go
@@ -133,29 +133,30 @@ func fetchReviewPage(ctx context.Context, api *tvssClient, target string, form u
 		method = http.MethodPost
 		reader = strings.NewReader(form.Encode())
 	}
-	req, err := api.newRequest(ctx, method, target, reader)
-	if err != nil {
-		return nil, shop.Errorf(shop.ErrInternal, "build reviews request")
-	}
-	req.Header.Set("User-Agent", mobileUA)
-	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
-	req.Header.Set("Accept", "text/html")
+	headers := make(http.Header)
 	if form != nil {
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
-		req.Header.Set("X-Requested-With", "XMLHttpRequest")
-		req.Header.Set("anti-csrftoken-a2z", csrf)
+		headers.Set("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
+		headers.Set("X-Requested-With", "XMLHttpRequest")
+		headers.Set("anti-csrftoken-a2z", csrf)
 	}
-	client := *api.http
-	client.CheckRedirect = func(r *http.Request, via []*http.Request) error {
-		if r.URL.Scheme != "https" || r.URL.Host != req.URL.Host || strings.HasPrefix(r.URL.Path, "/ap/") {
-			return http.ErrUseLastResponse
-		}
-		if len(via) >= 5 {
-			return http.ErrUseLastResponse
-		}
-		return nil
+	targetURL, err := url.Parse(target)
+	if err != nil {
+		return nil, shop.Errorf(shop.ErrInternal, "parse reviews URL")
 	}
-	resp, err := client.Do(req)
+	resp, err := api.http.do(ctx, method, target, reader, requestOptions{
+		profile: profileWeb,
+		cookies: api.cookies,
+		headers: headers,
+		checkRedirect: func(r *http.Request, via []*http.Request) error {
+			if r.URL.Scheme != "https" || r.URL.Host != targetURL.Host || strings.HasPrefix(r.URL.Path, "/ap/") {
+				return http.ErrUseLastResponse
+			}
+			if len(via) >= 5 {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	})
 	if err != nil {
 		return nil, shop.Errorf(shop.ErrNetwork, "reviews request failed")
 	}

--- a/internal/provider/amazon/search.go
+++ b/internal/provider/amazon/search.go
@@ -157,16 +157,10 @@ func (s *Store) searchASINs(ctx context.Context, api *tvssClient, keyword string
 
 	searchURL := fmt.Sprintf("https://www.%s/s?%s", s.handle, params.Encode())
 
-	req, err := api.newRequest(ctx, http.MethodGet, searchURL, nil)
-	if err != nil {
-		return nil, shop.Errorf(shop.ErrInternal, "build search request: %v", err)
-	}
-
-	req.Header.Set("User-Agent", mobileUA)
-	req.Header.Set("Accept", "text/html")
-	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
-
-	resp, err := api.http.Do(req)
+	resp, err := api.http.do(ctx, http.MethodGet, searchURL, nil, requestOptions{
+		profile: profileWeb,
+		cookies: api.cookies,
+	})
 	if err != nil {
 		return nil, shop.Errorf(shop.ErrNetwork, "search request: %v", err)
 	}

--- a/internal/provider/amazon/state.go
+++ b/internal/provider/amazon/state.go
@@ -16,14 +16,15 @@ const (
 // checkoutState is the persisted checkout session. Contains everything
 // PlaceOrder needs to sign the purchase without any additional network calls.
 type checkoutState struct {
-	PurchaseID string               `json:"purchaseId"`
-	Items      []checkoutStateItem  `json:"items"`
-	CreatedAt  string               `json:"createdAt"`
+	PurchaseID string              `json:"purchaseId"`
+	Items      []checkoutStateItem `json:"items"`
+	CreatedAt  string              `json:"createdAt"`
 }
 
 // checkoutStateItem is the minimal data needed for the sign request.
 // Fields map directly to the TVSS CheckoutPurchaseSignItem from the APK:
-//   id (cartId), asin, offerId, quantity (always 0).
+//
+//	id (cartId), asin, offerId, quantity (always 0).
 type checkoutStateItem struct {
 	ID      string `json:"id"`
 	ASIN    string `json:"asin"`

--- a/internal/provider/amazon/tvss.go
+++ b/internal/provider/amazon/tvss.go
@@ -9,35 +9,35 @@ import "encoding/json"
 
 // tvssProduct is the full product response from GET /products/{asin}.
 type tvssProduct struct {
-	ASIN                     string                    `json:"asin"`
-	Title                    string                    `json:"title"`
-	ByLine                   string                    `json:"byLine"`
-	Price                    flexString                    `json:"price"`
-	ListPrice                flexString                    `json:"listPrice"`
-	PricePerUnit             *tvssPricePerUnit         `json:"pricePerUnit,omitempty"`
-	ShippingDetails          *tvssShippingDetails      `json:"shippingDetails,omitempty"`
-	Badge                    *tvssBadge                `json:"badge,omitempty"`
-	CustomerReviewsCount     int                       `json:"customerReviewsCount"`
-	AverageOverallRating     float64                   `json:"averageOverallRating"`
-	ProductAvailability      *tvssAvailabilityDetails  `json:"productAvailabilityDetails,omitempty"`
-	OfferID                  string                    `json:"offerId"`
-	ProductGroupID           string                    `json:"productGroupId"`
-	VariationParentASIN      string                    `json:"variationParentAsin"`
-	VariationPriceRange      flexString                    `json:"variationPriceRange"`
-	ProductImageURLs         []string                  `json:"productImageUrls"`
-	ProductVideos            []tvssProductVideo        `json:"productVideos"`
-	VariationLabels          []tvssVariationLabel      `json:"variationLabels"`
-	MerchantInfo             *tvssMerchantInfo         `json:"merchantInfo,omitempty"`
-	Details                  map[string]string         `json:"details"`
-	Description              map[string][]string       `json:"description"`
-	PrimeExclusive           bool                      `json:"primeExclusive"`
-	MediaRating              string                    `json:"mediaRating"`
+	ASIN                 string                   `json:"asin"`
+	Title                string                   `json:"title"`
+	ByLine               string                   `json:"byLine"`
+	Price                flexString               `json:"price"`
+	ListPrice            flexString               `json:"listPrice"`
+	PricePerUnit         *tvssPricePerUnit        `json:"pricePerUnit,omitempty"`
+	ShippingDetails      *tvssShippingDetails     `json:"shippingDetails,omitempty"`
+	Badge                *tvssBadge               `json:"badge,omitempty"`
+	CustomerReviewsCount int                      `json:"customerReviewsCount"`
+	AverageOverallRating float64                  `json:"averageOverallRating"`
+	ProductAvailability  *tvssAvailabilityDetails `json:"productAvailabilityDetails,omitempty"`
+	OfferID              string                   `json:"offerId"`
+	ProductGroupID       string                   `json:"productGroupId"`
+	VariationParentASIN  string                   `json:"variationParentAsin"`
+	VariationPriceRange  flexString               `json:"variationPriceRange"`
+	ProductImageURLs     []string                 `json:"productImageUrls"`
+	ProductVideos        []tvssProductVideo       `json:"productVideos"`
+	VariationLabels      []tvssVariationLabel     `json:"variationLabels"`
+	MerchantInfo         *tvssMerchantInfo        `json:"merchantInfo,omitempty"`
+	Details              map[string]string        `json:"details"`
+	Description          map[string][]string      `json:"description"`
+	PrimeExclusive       bool                     `json:"primeExclusive"`
+	MediaRating          string                   `json:"mediaRating"`
 }
 
 type tvssPricePerUnit struct {
 	UnitPrice flexString `json:"unitPrice"`
-	BaseValue string `json:"baseValue"`
-	BaseUnit  string `json:"baseUnit"`
+	BaseValue string     `json:"baseValue"`
+	BaseUnit  string     `json:"baseUnit"`
 }
 
 type tvssShippingDetails struct {
@@ -82,18 +82,18 @@ type tvssBasicProductEntity struct {
 }
 
 type tvssBasicProduct struct {
-	ASIN                 string   `json:"asin"`
-	Title                string   `json:"title"`
-	ImageURL             string   `json:"imageUrl"`
-	ListPrice            flexString   `json:"listPrice"`
-	AverageOverallRating float64  `json:"averageOverallRating"`
-	CustomerReviewsCount int      `json:"customerReviewsCount"`
-	ProductImageURLs     []string `json:"productImageUrls"`
-	VariationPriceRange  flexString   `json:"variationPriceRange"`
+	ASIN                 string     `json:"asin"`
+	Title                string     `json:"title"`
+	ImageURL             string     `json:"imageUrl"`
+	ListPrice            flexString `json:"listPrice"`
+	AverageOverallRating float64    `json:"averageOverallRating"`
+	CustomerReviewsCount int        `json:"customerReviewsCount"`
+	ProductImageURLs     []string   `json:"productImageUrls"`
+	VariationPriceRange  flexString `json:"variationPriceRange"`
 }
 
 type tvssBasicOffer struct {
-	Price flexString     `json:"price"`
+	Price flexString `json:"price"`
 	Badge *tvssBadge `json:"badge,omitempty"`
 }
 
@@ -108,15 +108,15 @@ type tvssBasicProductsResponse struct {
 
 // tvssReviewsResponse is the response from GET /products/{asin}/customer-reviews.
 type tvssReviewsResponse struct {
-	OneStarCount       int                    `json:"oneStarCount"`
-	TwoStarCount       int                    `json:"twoStarCount"`
-	ThreeStarCount     int                    `json:"threeStarCount"`
-	FourStarCount      int                    `json:"fourStarCount"`
-	FiveStarCount      int                    `json:"fiveStarCount"`
+	OneStarCount       int                     `json:"oneStarCount"`
+	TwoStarCount       int                     `json:"twoStarCount"`
+	ThreeStarCount     int                     `json:"threeStarCount"`
+	FourStarCount      int                     `json:"fourStarCount"`
+	FiveStarCount      int                     `json:"fiveStarCount"`
 	ProductStarRatings *tvssProductStarRatings `json:"productStarRatings"`
-	Reviews            []tvssReview           `json:"reviews"`
-	PageNext           string                 `json:"pageNext"`
-	UsingPageNext      bool                   `json:"usingPageNext"`
+	Reviews            []tvssReview            `json:"reviews"`
+	PageNext           string                  `json:"pageNext"`
+	UsingPageNext      bool                    `json:"usingPageNext"`
 }
 
 type tvssProductStarRatings struct {
@@ -130,15 +130,15 @@ type tvssProductStarRatings struct {
 }
 
 type tvssReview struct {
-	AuthorName         string             `json:"authorName"`
-	Title              string             `json:"title"`
-	Text               string             `json:"text"`
-	OverallRating      *float64           `json:"overallRating"`
-	SubmissionDate     string             `json:"submissionDate"` // epoch millis or date string
-	IsVerifiedPurchase *bool              `json:"isVerifiedPurchase"`
-	IsVine             *bool              `json:"isVine"`
-	ImageURLs          []tvssReviewImage  `json:"imageUrls"`
-	OriginDescription  string             `json:"originDescription"`
+	AuthorName         string            `json:"authorName"`
+	Title              string            `json:"title"`
+	Text               string            `json:"text"`
+	OverallRating      *float64          `json:"overallRating"`
+	SubmissionDate     string            `json:"submissionDate"` // epoch millis or date string
+	IsVerifiedPurchase *bool             `json:"isVerifiedPurchase"`
+	IsVine             *bool             `json:"isVine"`
+	ImageURLs          []tvssReviewImage `json:"imageUrls"`
+	OriginDescription  string            `json:"originDescription"`
 }
 
 type tvssReviewImage struct {
@@ -156,15 +156,15 @@ type tvssVariationsResponse struct {
 }
 
 type tvssVariationDimension struct {
-	DimensionKey   string   `json:"dimensionKey"`
-	DisplayString  string   `json:"displayString"`
-	Values         []string `json:"values"`
+	DimensionKey    string   `json:"dimensionKey"`
+	DisplayString   string   `json:"displayString"`
+	Values          []string `json:"values"`
 	SwatchImageURLs []string `json:"swatchImageUrls"`
 }
 
 type tvssVariation struct {
 	ASIN             string     `json:"asin"`
-	BuyingPrice      flexString     `json:"buyingPrice"`
+	BuyingPrice      flexString `json:"buyingPrice"`
 	Badge            *tvssBadge `json:"badge,omitempty"`
 	VariationIndices []int      `json:"variationIndices"`
 }
@@ -198,7 +198,7 @@ type tvssCartMessage struct {
 type tvssCartResponse struct {
 	Items    []tvssCartItem    `json:"items"`
 	Messages []tvssCartMessage `json:"messages"`
-	Subtotal flexString            `json:"subtotal"`
+	Subtotal flexString        `json:"subtotal"`
 }
 
 type tvssCartItem struct {
@@ -207,7 +207,7 @@ type tvssCartItem struct {
 	OfferID          string     `json:"offerId"`
 	Title            string     `json:"title"`
 	ByLine           string     `json:"byLine"`
-	Price            flexString     `json:"price"`
+	Price            flexString `json:"price"`
 	ImageURL         string     `json:"imageUrl"`
 	Quantity         int        `json:"quantity"`
 	QuantityEditable bool       `json:"quantityEditable"`
@@ -244,19 +244,19 @@ type tvssPurchaseInitiateItem struct {
 // tvssPurchaseResponse is the response from POST /checkout/purchase/initiate
 // and also the base response for checkout state queries.
 type tvssPurchaseResponse struct {
-	PurchaseID           string              `json:"purchaseId"`
-	Destinations         *tvssDestinations   `json:"destinations,omitempty"`
-	PaymentMethods       *tvssPaymentMethods `json:"paymentMethods,omitempty"`
-	LineItems            *tvssLineItems      `json:"lineItems,omitempty"`
-	PurchaseTotals       *tvssPurchaseTotals `json:"purchaseTotals,omitempty"`
-	DeliveryGroups       *tvssDeliveryGroups `json:"deliveryGroups,omitempty"`
+	PurchaseID           string                    `json:"purchaseId"`
+	Destinations         *tvssDestinations         `json:"destinations,omitempty"`
+	PaymentMethods       *tvssPaymentMethods       `json:"paymentMethods,omitempty"`
+	LineItems            *tvssLineItems            `json:"lineItems,omitempty"`
+	PurchaseTotals       *tvssPurchaseTotals       `json:"purchaseTotals,omitempty"`
+	DeliveryGroups       *tvssDeliveryGroups       `json:"deliveryGroups,omitempty"`
 	PurchaseRestrictions []tvssPurchaseRestriction `json:"purchaseRestrictions,omitempty"`
-	PurchaseState        []string            `json:"purchaseState,omitempty"`
+	PurchaseState        []string                  `json:"purchaseState,omitempty"`
 }
 
 type tvssDestinations struct {
-	Destinations     []tvssDestination `json:"destinations"`
-	DestinationList  []tvssDestinationDetail `json:"destinationList"`
+	Destinations    []tvssDestination       `json:"destinations"`
+	DestinationList []tvssDestinationDetail `json:"destinationList"`
 }
 
 func (d *tvssDestinations) UnmarshalJSON(data []byte) error {
@@ -295,8 +295,8 @@ type tvssAddressDisplay struct {
 
 type tvssPaymentMethods struct {
 	CreditOrDebitCard *tvssCreditOrDebitCard `json:"creditOrDebitCard,omitempty"`
-	GiftCardAndPromo  *tvssGiftCard         `json:"giftCardAndPromo,omitempty"`
-	BankAccount       *tvssBankAccount      `json:"bankAccount,omitempty"`
+	GiftCardAndPromo  *tvssGiftCard          `json:"giftCardAndPromo,omitempty"`
+	BankAccount       *tvssBankAccount       `json:"bankAccount,omitempty"`
 }
 
 func (p *tvssPaymentMethods) UnmarshalJSON(data []byte) error {
@@ -305,11 +305,11 @@ func (p *tvssPaymentMethods) UnmarshalJSON(data []byte) error {
 }
 
 type tvssCreditOrDebitCard struct {
-	ID         string                 `json:"id"`
-	EndingIn   string                 `json:"endingIn"`
-	Issuer     flexString             `json:"issuer"`
-	Expiry     *tvssCardExpiry        `json:"expiry,omitempty"`
-	NameOnCard string                 `json:"nameOnCard"`
+	ID         string          `json:"id"`
+	EndingIn   string          `json:"endingIn"`
+	Issuer     flexString      `json:"issuer"`
+	Expiry     *tvssCardExpiry `json:"expiry,omitempty"`
+	NameOnCard string          `json:"nameOnCard"`
 }
 
 type tvssCardExpiry struct {
@@ -335,13 +335,13 @@ func (l *tvssLineItems) UnmarshalJSON(data []byte) error {
 }
 
 type tvssLineItem struct {
-	ASIN          string         `json:"asin"`
-	OfferID       string         `json:"offerId"`
-	Title         string         `json:"title"`
-	ByLine        string         `json:"byLine"`
+	ASIN          string             `json:"asin"`
+	OfferID       string             `json:"offerId"`
+	Title         string             `json:"title"`
+	ByLine        string             `json:"byLine"`
 	Price         flexString         `json:"price"`
-	ImageURL      string         `json:"imageUrl"`
-	Quantity      *int           `json:"quantity,omitempty"`
+	ImageURL      string             `json:"imageUrl"`
+	Quantity      *int               `json:"quantity,omitempty"`
 	LineItemPrice *tvssLineItemPrice `json:"lineItemPrice,omitempty"`
 }
 
@@ -362,8 +362,8 @@ type tvssDiscount struct {
 }
 
 type tvssPurchaseTotals struct {
-	PurchaseTotal     *tvssPurchaseTotal    `json:"purchaseTotal,omitempty"`
-	Subtotals         []tvssPurchaseSubtotal `json:"subtotals,omitempty"`
+	PurchaseTotal *tvssPurchaseTotal     `json:"purchaseTotal,omitempty"`
+	Subtotals     []tvssPurchaseSubtotal `json:"subtotals,omitempty"`
 }
 
 func (p *tvssPurchaseTotals) UnmarshalJSON(data []byte) error {
@@ -398,11 +398,11 @@ type tvssDeliveryGroup struct {
 }
 
 type tvssDeliveryOption struct {
-	ID           string `json:"id"`
+	ID            string `json:"id"`
 	DisplayString string `json:"displayString"`
-	DisplayName  string `json:"displayName"`
-	DisplayPrice string `json:"displayPrice"`
-	Selected     bool   `json:"selected"`
+	DisplayName   string `json:"displayName"`
+	DisplayPrice  string `json:"displayPrice"`
+	Selected      bool   `json:"selected"`
 }
 
 type tvssPurchaseRestriction struct {
@@ -443,7 +443,7 @@ func (r *tvssCheckoutOrdersResponse) UnmarshalJSON(data []byte) error {
 }
 
 type tvssCheckoutOrder struct {
-	ID         string                    `json:"id"`
+	ID         string                       `json:"id"`
 	ItemGroups []tvssCheckoutOrderItemGroup `json:"itemGroups"`
 }
 
@@ -454,5 +454,3 @@ type tvssCheckoutOrderItemGroup struct {
 type tvssCheckoutOrderItem struct {
 	Quantity int `json:"quantity"`
 }
-
-

--- a/open.go
+++ b/open.go
@@ -1,0 +1,35 @@
+package shop
+
+import (
+	"context"
+	"os"
+	"strings"
+)
+
+// Open creates a Store for handle using configDir for auth and provider
+// state. Library callers own that directory; it is not ~/.config/shop unless
+// they pass that path.
+func Open(ctx context.Context, handle, configDir string) (Store, error) {
+	handle = strings.TrimSpace(handle)
+	configDir = strings.TrimSpace(configDir)
+	if handle == "" {
+		return nil, Errorf(ErrInvalidInput, "store handle is required")
+	}
+	if configDir == "" {
+		return nil, Errorf(ErrInvalidInput, "config directory is required")
+	}
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		return nil, Errorf(ErrConfigError, "create config directory: %v", err)
+	}
+
+	for _, provider := range Providers() {
+		info, err := provider.Detect(ctx, handle)
+		if err != nil || info == nil {
+			continue
+		}
+
+		return provider.Store(ctx, info.Domain, configDir)
+	}
+
+	return nil, Errorf(ErrStoreNotFound, "store %q not found", handle)
+}

--- a/order.go
+++ b/order.go
@@ -1,5 +1,12 @@
 package shop
 
+// CartAddOptions controls how a product is added to a cart.
+type CartAddOptions struct {
+	// OfferID selects a specific offer returned by Store.Offers. Empty lets the
+	// provider select its default offer.
+	OfferID string `json:"offerId,omitempty"`
+}
+
 // CartContents is a snapshot of the current cart state.
 type CartContents struct {
 	Items    []CartEntry `json:"items"`

--- a/search.go
+++ b/search.go
@@ -134,4 +134,5 @@ type ShippingInfo struct {
 	Price       *Money `json:"price,omitempty"`
 	Description string `json:"description,omitempty"`
 	Speed       string `json:"speed,omitempty"`
+	From        string `json:"from,omitempty"`
 }

--- a/shop.go
+++ b/shop.go
@@ -89,7 +89,9 @@ type Store interface {
 // provider implementation — the CLI only reads it via View().
 type Cart interface {
 	// Add adds a product to the cart. quantity must be >= 1.
-	Add(ctx context.Context, id string, quantity int) (*CartContents, error)
+	// Set options.OfferID to select an offer returned by Store.Offers; nil or an
+	// empty OfferID lets the provider select its default offer.
+	Add(ctx context.Context, id string, quantity int, options *CartAddOptions) (*CartContents, error)
 
 	// Remove removes a product entirely from the cart.
 	Remove(ctx context.Context, id string) (*CartContents, error)


### PR DESCRIPTION
## Summary

- replace Amazon's buy-box-only offers implementation with the public All Offers Display catalog
- expose the fulfillment source separately as `shipping.from`
- support stable logical pagination and condition filtering over Amazon's fixed offer pages
- decode and preserve provider offer IDs for selected-offer cart operations
- add provider-neutral selected-offer cart support through `CartAddOptions`
- add `shop cart add <product-id> --offer <offer-id>` using IDs returned by `shop offers`

## Design

- the public AOD catalog is the single authoritative source for seller discovery
- a dedicated AOD transport omits Go's rejected automatic compression header and safely decodes Amazon's unsolicited gzip response
- offer discovery does not require Amazon login or mix authenticated TVSS state into public HTML requests
- TVSS remains responsible for authenticated product, cart, and checkout operations
- incomplete or rate-limited AOD responses return an explicit error rather than a partial catalog
- native traversal is capped at 100 Amazon pages and response bodies at 8 MiB

## Verification

- `gofmt`
- `go build ./...`
- `go vet ./...`
- Amazon provider tests repeated 100 times
- full repository race detector
- `git diff --check`
- live Destined Rivals pagination returned two non-overlapping five-offer pages with nonempty IDs
- live Mega Box and Hanger Box requests found Amazon-sold offers with correct `hasMore` state

Supersedes #1 with a provider-neutral selected-offer API instead of an Amazon-specific offer-ID escape hatch.
